### PR TITLE
Fix assert_invalid_fd

### DIFF
--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -136,6 +136,8 @@ async fn poll_once(future: impl std::future::Future) {
     .await;
 }
 
+/// Test if this file descriptor is invalid
+/// Will panic if the descriptor is valid
 fn assert_invalid_fd(fd: RawFd) {
     use std::fs::File;
     use std::io;
@@ -144,7 +146,15 @@ fn assert_invalid_fd(fd: RawFd) {
     let mut buf = vec![];
 
     match f.read_to_end(&mut buf) {
-        Err(ref e) if e.kind() == io::ErrorKind::Other => {}
-        res => panic!("{:?}", res),
+        Err(ref err) => {
+            match err.kind() {
+                io::ErrorKind::Other => { /* expected */ },
+                // returns io::Error::Uncategorized in some cases
+                _ => println!("Got unexpected error {:?}", err),
+            }
+        }
+        Ok(_) => {
+            panic!("Expected file descriptor to be invalid but was valid");
+        }
     }
 }


### PR DESCRIPTION
I noticed the two tests are panicking on my machine like below:

```
---- drop_off_runtime stdout ----
thread 'drop_off_runtime' panicked at 'Err(Os { code: 9, kind: Uncategorized, message: "Bad file descriptor" })', tests/fs_file.rs:148:16
stack backtrace:
   0: rust_begin_unwind
             at /rustc/ae90dcf0207c57c3034f00b07048d63f8b2363c8/library/std/src/panicking.rs:517:5
   1: std::panicking::begin_panic_fmt
             at /rustc/ae90dcf0207c57c3034f00b07048d63f8b2363c8/library/std/src/panicking.rs:460:5
   2: fs_file::assert_invalid_fd
             at ./tests/fs_file.rs:148:16
   3: fs_file::drop_off_runtime
             at ./tests/fs_file.rs:103:5
   4: fs_file::drop_off_runtime::{{closure}}
             at ./tests/fs_file.rs:94:1
   5: core::ops::function::FnOnce::call_once
             at /rustc/ae90dcf0207c57c3034f00b07048d63f8b2363c8/library/core/src/ops/function.rs:227:5
   6: core::ops::function::FnOnce::call_once
             at /rustc/ae90dcf0207c57c3034f00b07048d63f8b2363c8/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

It seems like on my setup `ErrorKind` is `Uncategorized` not `Other`. The former cannot be handled easily without enabling a experimental features, so I changed the test to success on any type of error for now.

Let me know your thoughts on this. Might be a recent change in nightly that broke this...