### PR TITLE
Fix panic in Deref/DerefMut for Slice extending into uninitialized part of the buffer

### DIFF
--- a/src/buf/slice.rs
+++ b/src/buf/slice.rs
@@ -165,26 +165,3 @@ unsafe impl<T: IoBufMut> IoBufMut for Slice<T> {
         self.buf.set_init(self.begin + pos);
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use crate::buf::{IoBuf, IoBufMut};
-    use std::mem;
-
-    #[test]
-    fn can_deref_slice_into_uninit_buf() {
-        let buf = Vec::with_capacity(10).slice(..);
-        assert!(buf[..].is_empty());
-        let _ = buf.stable_ptr();
-        assert_eq!(buf.bytes_init(), 0);
-        assert_eq!(buf.bytes_total(), 10);
-
-        let mut v = Vec::with_capacity(10);
-        v.push(42);
-        let mut buf = v.slice(..);
-        assert_eq!(mem::replace(&mut buf[0], 0u8), 42u8);
-        let _ = buf.stable_mut_ptr();
-        assert_eq!(buf.bytes_init(), 1);
-        assert_eq!(buf.bytes_total(), 10);
-    }
-}

--- a/src/buf/slice.rs
+++ b/src/buf/slice.rs
@@ -144,7 +144,7 @@ impl<T: IoBufMut> ops::DerefMut for Slice<T> {
 
 unsafe impl<T: IoBuf> IoBuf for Slice<T> {
     fn stable_ptr(&self) -> *const u8 {
-        ops::Deref::deref(self).as_ptr()
+        super::deref(&self.buf)[self.begin..].as_ptr()
     }
 
     fn bytes_init(&self) -> usize {
@@ -158,7 +158,7 @@ unsafe impl<T: IoBuf> IoBuf for Slice<T> {
 
 unsafe impl<T: IoBufMut> IoBufMut for Slice<T> {
     fn stable_mut_ptr(&mut self) -> *mut u8 {
-        ops::DerefMut::deref_mut(self).as_mut_ptr()
+        super::deref_mut(&mut self.buf)[self.begin..].as_mut_ptr()
     }
 
     unsafe fn set_init(&mut self, pos: usize) {

--- a/tests/buf.rs
+++ b/tests/buf.rs
@@ -1,5 +1,7 @@
 use tokio_uring::buf::{IoBuf, IoBufMut};
 
+use std::mem;
+
 #[test]
 fn test_vec() {
     let mut v = vec![];
@@ -116,4 +118,23 @@ macro_rules! test_slice {
 test_slice! {
     vec => Vec::from(DATA);
     slice => DATA;
+}
+
+#[test]
+fn can_deref_slice_into_uninit_buf() {
+    let buf = Vec::with_capacity(10).slice(..);
+    let _ = buf.stable_ptr();
+    assert_eq!(buf.bytes_init(), 0);
+    assert_eq!(buf.bytes_total(), 10);
+    assert!(buf[..].is_empty());
+
+    let mut v = Vec::with_capacity(10);
+    v.push(42);
+    let mut buf = v.slice(..);
+    let _ = buf.stable_mut_ptr();
+    assert_eq!(buf.bytes_init(), 1);
+    assert_eq!(buf.bytes_total(), 10);
+    assert_eq!(mem::replace(&mut buf[0], 0), 42);
+    buf.copy_from_slice(&[43]);
+    assert_eq!(&buf[..], &[43]);
 }


### PR DESCRIPTION
The `Deref` and `DerefMut` impls for `Slice` did not ensure that the end of the returned byte slice is clipped to the end of initialized data in the buffer.

Fixes #45.