### PR TITLE
Implement Debug for File

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -338,6 +338,8 @@ impl AsRawFd for File {
 
 impl fmt::Debug for File {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "File {{ fd: {fd} }}", fd = self.fd.raw_fd())
+        f.debug_struct("File")
+            .field("fd", &self.fd.raw_fd())
+            .finish()
     }
 }

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -2,6 +2,7 @@ use crate::buf::{IoBuf, IoBufMut};
 use crate::driver::{Op, SharedFd};
 use crate::fs::OpenOptions;
 
+use std::fmt;
 use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
@@ -332,5 +333,11 @@ impl File {
 impl AsRawFd for File {
     fn as_raw_fd(&self) -> RawFd {
         self.fd.raw_fd()
+    }
+}
+
+impl fmt::Debug for File {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "File {{ fd: {fd} }}", fd = self.fd.raw_fd())
     }
 }


### PR DESCRIPTION
Closes #58 

Feel free to suggest improvements. From what I can see right now, it is not possible to generate the same output as the `Debug` implementation for `std::fs::File`... or am I missing something?