### PR TITLE
fix build and test errors

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -108,7 +108,7 @@ impl Inner {
                     self.uring.submission().sync();
                     return Ok(());
                 }
-                Err(ref e) if e.kind() == io::ErrorKind::Other => {
+                Err(ref e) if e.raw_os_error() == Some(libc::EBUSY) => {
                     self.tick();
                 }
                 Err(e) => {

--- a/src/driver/op.rs
+++ b/src/driver/op.rs
@@ -25,6 +25,10 @@ pub(crate) struct Op<T: 'static> {
 pub(crate) struct Completion<T> {
     pub(crate) data: T,
     pub(crate) result: io::Result<u32>,
+    #[cfg_attr(
+        not(test),  // the field is currently only read in tests
+        allow(dead_code)
+    )]
     pub(crate) flags: u32,
 }
 

--- a/src/fs/directory.rs
+++ b/src/fs/directory.rs
@@ -12,8 +12,10 @@ use std::path::Path;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     tokio_uring::start(async {
-///         remove_dir("/some/dir")?;
-///     });
+///         remove_dir("/some/dir").await?;
+///         Ok::<(), std::io::Error>(())
+///     })?;
+///     Ok(())
 /// }
 /// ```
 pub async fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -349,12 +349,14 @@ impl fmt::Debug for File {
 /// # Examples
 ///
 /// ```no_run
-/// use tokio_uring::fs::remove_dir;
+/// use tokio_uring::fs::remove_file;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     tokio_uring::start(async {
-///         remove_file("/some/file.txt")?;
-///     });
+///         remove_file("/some/file.txt").await?;
+///         Ok::<(), std::io::Error>(())
+///     })?;
+///     Ok(())
 /// }
 /// ```
 pub async fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {

--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -138,13 +138,12 @@ async fn poll_once(future: impl std::future::Future) {
 
 fn assert_invalid_fd(fd: RawFd) {
     use std::fs::File;
-    use std::io;
 
     let mut f = unsafe { File::from_raw_fd(fd) };
     let mut buf = vec![];
 
     match f.read_to_end(&mut buf) {
-        Err(ref e) if e.kind() == io::ErrorKind::Other => {}
+        Err(ref e) if e.raw_os_error() == Some(libc::EBADF) => {}
         res => panic!("{:?}", res),
     }
 }


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/85746 , `ErrorKind::Other`
is not what it used to. This library depended on `ErrorKind::Other` in a
couple places for error handling, and that's I believe why the tests
were failing.

I've changed those bits of error handling to rely on the `raw_os_error`
instead. This should be more granular than the `kind`, but also more
stable. I believe I've chosen the right error codes that we were
supposed to handle, and the tests now pass (in my machine anyway lol).

I've also changed a couple doc tests that were failing to compile.

After these changes, running `cargo test` succeeds.

Fixes: https://github.com/tokio-rs/tokio-uring/issues/59