### PR TITLE
Add unix stream & listener

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ scoped-tls = "1.0.0"
 slab = "0.4.2"
 libc = "0.2.80"
 io-uring = { version = "0.5.0", features = [ "unstable" ] }
-socket2 = "0.4.4"
+socket2 = { version = "0.4.4", features = [ "all"] }
 bytes = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ slab = "0.4.2"
 libc = "0.2.80"
 io-uring = { version = "0.5.0", features = [ "unstable" ] }
 os_socketaddr = "0.2.0"
+socket2 = "0.4.4"
 bytes = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ scoped-tls = "1.0.0"
 slab = "0.4.2"
 libc = "0.2.80"
 io-uring = { version = "0.5.0", features = [ "unstable" ] }
-os_socketaddr = "0.2.0"
 socket2 = "0.4.4"
 bytes = { version = "1.0", optional = true }
 

--- a/examples/mix.rs
+++ b/examples/mix.rs
@@ -16,7 +16,7 @@ fn main() {
 
     tokio_uring::start(async {
         // Start a TCP listener
-        let listener = TcpListener::bind("0.0.0.0:8080").unwrap();
+        let listener = TcpListener::bind("0.0.0.0:8080".parse().unwrap()).unwrap();
 
         // Accept new sockets
         loop {

--- a/examples/mix.rs
+++ b/examples/mix.rs
@@ -16,7 +16,7 @@ fn main() {
 
     tokio_uring::start(async {
         // Start a TCP listener
-        let listener = TcpListener::bind("0.0.0.0:8080".parse().unwrap()).unwrap();
+        let listener = TcpListener::bind("0.0.0.0:8080").unwrap();
 
         // Accept new sockets
         loop {

--- a/examples/unix_listener.rs
+++ b/examples/unix_listener.rs
@@ -1,4 +1,4 @@
-use std::{env};
+use std::env;
 
 use tokio_uring::net::UnixListener;
 

--- a/examples/unix_listener.rs
+++ b/examples/unix_listener.rs
@@ -1,0 +1,32 @@
+use std::{env};
+
+use tokio_uring::net::UnixListener;
+
+fn main() {
+    let args: Vec<_> = env::args().collect();
+
+    if args.len() <= 1 {
+        panic!("no addr specified");
+    }
+
+    let socket_addr: String = args[1].clone();
+
+    tokio_uring::start(async {
+        let listener = UnixListener::bind(&socket_addr).unwrap();
+
+        loop {
+            let stream = listener.accept().await.unwrap();
+            let socket_addr = socket_addr.clone();
+            tokio_uring::spawn(async move {
+                let buf = vec![1u8; 128];
+
+                let (result, buf) = stream.write(buf).await;
+                println!("written to {}: {}", &socket_addr, result.unwrap());
+
+                let (result, buf) = stream.read(buf).await;
+                let read = result.unwrap();
+                println!("read from {}: {:?}", &socket_addr, &buf[..read]);
+            });
+        }
+    });
+}

--- a/examples/unix_stream.rs
+++ b/examples/unix_stream.rs
@@ -1,0 +1,25 @@
+use std::env;
+
+use tokio_uring::net::UnixStream;
+
+fn main() {
+    let args: Vec<_> = env::args().collect();
+
+    if args.len() <= 1 {
+        panic!("no addr specified");
+    }
+
+    let socket_addr: &String = &args[1];
+
+    tokio_uring::start(async {
+        let stream = UnixStream::connect(socket_addr).await.unwrap();
+        let buf = vec![1u8; 128];
+
+        let (result, buf) = stream.write(buf).await;
+        println!("written: {}", result.unwrap());
+
+        let (result, buf) = stream.read(buf).await;
+        let read = result.unwrap();
+        println!("read: {:?}", &buf[..read]);
+    });
+}

--- a/src/driver/connect.rs
+++ b/src/driver/connect.rs
@@ -1,55 +1,20 @@
 use crate::driver::{Op, SharedFd};
-use os_socketaddr::OsSocketAddr;
 use socket2::SockAddr;
-use std::{io, net::SocketAddr};
+use std::io;
 
 /// Open a file
 pub(crate) struct Connect {
     fd: SharedFd,
-    os_socket_addr: OsSocketAddr,
+    socket_addr: SockAddr,
 }
 
 impl Op<Connect> {
     /// Submit a request to connect.
-    pub(crate) fn connect(fd: &SharedFd, socket_addr: SocketAddr) -> io::Result<Op<Connect>> {
+    pub(crate) fn connect(fd: &SharedFd, socket_addr: SockAddr) -> io::Result<Op<Connect>> {
         use io_uring::{opcode, types};
-
-        let os_socket_addr = OsSocketAddr::from(socket_addr);
 
         Op::submit_with(
             Connect {
-                fd: fd.clone(),
-                os_socket_addr,
-            },
-            |connect| {
-                opcode::Connect::new(
-                    types::Fd(connect.fd.raw_fd()),
-                    connect.os_socket_addr.as_ptr(),
-                    connect.os_socket_addr.len(),
-                )
-                .build()
-            },
-        )
-    }
-}
-
-pub(crate) struct ConnectUnix {
-    /// Holds a strong ref to the FD, preventing the file from being closed
-    /// while the operation is in-flight.
-    pub(crate) fd: SharedFd,
-    socket_addr: SockAddr,
-}
-
-impl Op<ConnectUnix> {
-    /// Submit a request to connect.
-    pub(crate) fn connect_unix(
-        fd: &SharedFd,
-        socket_addr: SockAddr,
-    ) -> io::Result<Op<ConnectUnix>> {
-        use io_uring::{opcode, types};
-
-        Op::submit_with(
-            ConnectUnix {
                 fd: fd.clone(),
                 socket_addr,
             },

--- a/src/driver/connect.rs
+++ b/src/driver/connect.rs
@@ -1,5 +1,6 @@
 use crate::driver::{Op, SharedFd};
 use os_socketaddr::OsSocketAddr;
+use socket2::SockAddr;
 use std::{io, net::SocketAddr};
 
 /// Open a file
@@ -25,6 +26,38 @@ impl Op<Connect> {
                     types::Fd(connect.fd.raw_fd()),
                     connect.os_socket_addr.as_ptr(),
                     connect.os_socket_addr.len(),
+                )
+                .build()
+            },
+        )
+    }
+}
+
+pub(crate) struct ConnectUnix {
+    /// Holds a strong ref to the FD, preventing the file from being closed
+    /// while the operation is in-flight.
+    pub(crate) fd: SharedFd,
+    socket_addr: SockAddr,
+}
+
+impl Op<ConnectUnix> {
+    /// Submit a request to connect.
+    pub(crate) fn connect_unix(
+        fd: &SharedFd,
+        socket_addr: SockAddr,
+    ) -> io::Result<Op<ConnectUnix>> {
+        use io_uring::{opcode, types};
+
+        Op::submit_with(
+            ConnectUnix {
+                fd: fd.clone(),
+                socket_addr,
+            },
+            |connect| {
+                opcode::Connect::new(
+                    types::Fd(connect.fd.raw_fd()),
+                    connect.socket_addr.as_ptr(),
+                    connect.socket_addr.len(),
                 )
                 .build()
             },

--- a/src/driver/op.rs
+++ b/src/driver/op.rs
@@ -145,7 +145,7 @@ where
                 Poll::Ready(Completion {
                     data: me.data.take().expect("unexpected operation state"),
                     result,
-                    flags: flags,
+                    flags,
                 })
             }
         }

--- a/src/driver/socket.rs
+++ b/src/driver/socket.rs
@@ -6,7 +6,7 @@ use socket2::SockAddr;
 use std::{
     io,
     net::SocketAddr,
-    os::unix::io::{AsRawFd, RawFd},
+    os::unix::io::{AsRawFd, IntoRawFd, RawFd},
     path::Path,
 };
 
@@ -104,7 +104,7 @@ impl Socket {
 
         sys_listener.bind(&addr)?;
 
-        let fd = SharedFd::new(sys_listener.as_raw_fd());
+        let fd = SharedFd::new(sys_listener.into_raw_fd());
 
         Ok(Self { fd })
     }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -15,6 +15,8 @@
 
 mod tcp;
 mod udp;
+mod unix;
 
 pub use tcp::{TcpListener, TcpStream};
 pub use udp::UdpSocket;
+pub use unix::{UnixListener, UnixStream};

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -1,9 +1,6 @@
 use super::TcpStream;
 use crate::driver::Socket;
-use std::{
-    io,
-    net::{SocketAddr, ToSocketAddrs},
-};
+use std::{io, net::SocketAddr};
 
 /// A TCP socket server, listening for connections.
 ///
@@ -17,10 +14,10 @@ use std::{
 /// use tokio_uring::net::TcpStream;
 ///
 /// fn main() {
-///     let listener = TcpListener::bind("127.0.0.1:2345").unwrap();
+///     let listener = TcpListener::bind("127.0.0.1:2345".parse().unwrap()).unwrap();
 ///
 ///     tokio_uring::start(async move {
-///         let tx_fut = TcpStream::connect("127.0.0.1:2345");
+///         let tx_fut = TcpStream::connect("127.0.0.1:2345".parse().unwrap());
 ///
 ///         let rx_fut = listener.accept();
 ///
@@ -48,17 +45,10 @@ impl TcpListener {
     /// method.
     ///
     /// [`ToSocketAddrs`]: trait@std::net::ToSocketAddrs
-    pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
-        let mut sockets = addr.to_socket_addrs()?;
-        while let Some(socket_addr) = sockets.next() {
-            let socket = Socket::bind(socket_addr, libc::SOCK_STREAM)?;
-            socket.listen(1024)?;
-            return Ok(TcpListener { inner: socket });
-        }
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "Could not connect to supplied sockets",
-        ))
+    pub fn bind(addr: SocketAddr) -> io::Result<Self> {
+        let socket = Socket::bind(addr, libc::SOCK_STREAM)?;
+        socket.listen(1024)?;
+        return Ok(TcpListener { inner: socket });
     }
 
     /// Accepts a new incoming connection from this listener.

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -46,6 +46,8 @@ impl TcpListener {
     /// Binding with a port number of 0 will request that the OS assigns a port
     /// to this listener. The port allocated can be queried via the `local_addr`
     /// method.
+    ///
+    /// [`ToSocketAddrs`]: trait@std::net::ToSocketAddrs
     pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
         let mut sockets = addr.to_socket_addrs()?;
         while let Some(socket_addr) = sockets.next() {
@@ -70,10 +72,7 @@ impl TcpListener {
         let (socket, socket_addr) = self.inner.accept().await?;
         let stream = TcpStream { inner: socket };
         let socket_addr = socket_addr.ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "Could not get socket IP address",
-            )
+            io::Error::new(io::ErrorKind::Other, "Could not get socket IP address")
         })?;
         Ok((stream, socket_addr))
     }

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -41,10 +41,10 @@ impl TcpListener {
     /// The returned listener is ready for accepting connections.
     ///
     /// Binding with a port number of 0 will request that the OS assigns a port
-    /// to this listener. The port allocated can be queried via the `local_addr`
-    /// method.
+    /// to this listener.
     ///
-    /// [`ToSocketAddrs`]: trait@std::net::ToSocketAddrs
+    /// In the future, the port allocated can be queried via a (blocking) `local_addr`
+    /// method.
     pub fn bind(addr: SocketAddr) -> io::Result<Self> {
         let socket = Socket::bind(addr, libc::SOCK_STREAM)?;
         socket.listen(1024)?;

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -69,6 +69,12 @@ impl TcpListener {
     pub async fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
         let (socket, socket_addr) = self.inner.accept().await?;
         let stream = TcpStream { inner: socket };
+        let socket_addr = socket_addr.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "Could not get socket IP address",
+            )
+        })?;
         Ok((stream, socket_addr))
     }
 }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -52,7 +52,7 @@ impl TcpStream {
         let mut sockets = addr.to_socket_addrs()?;
         while let Some(socket_addr) = sockets.next() {
             let socket = Socket::new(socket_addr, libc::SOCK_STREAM)?;
-            socket.connect(socket_addr).await?;
+            socket.connect(socket2::SockAddr::from(socket_addr)).await?;
             let tcp_stream = TcpStream { inner: socket };
             return Ok(tcp_stream);
         }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -19,9 +19,7 @@ use crate::{
 /// fn main() -> std::io::Result<()> {
 ///     tokio_uring::start(async {
 ///         // Connect to a peer
-///         let mut stream = TcpStream::connect(
-///             "127.0.0.1:8080".to_socket_addrs().unwrap().next().unwrap()
-///         ).await?;
+///         let mut stream = TcpStream::connect("127.0.0.1:8080").await?;
 ///
 ///         // Write some data.
 ///         let (result, _) = stream.write(b"hello world!".as_slice()).await;

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -38,16 +38,7 @@ pub struct TcpStream {
 }
 
 impl TcpStream {
-    /// Opens a TCP connection to a remote host.
-    ///
-    /// `addr` is an address of the remote host. Anything which implements the
-    /// [`ToSocketAddrs`] trait can be supplied as the address.  If `addr`
-    /// yields multiple addresses, connect will be attempted with each of the
-    /// addresses until a connection is successful. If none of the addresses
-    /// result in a successful connection, the error returned from the last
-    /// connection attempt (the last address) is returned.
-    ///
-    /// [`ToSocketAddrs`]: trait@std::net::ToSocketAddrs
+    /// Opens a TCP connection to a remote host at the given `SocketAddr`
     pub async fn connect(addr: SocketAddr) -> io::Result<TcpStream> {
         let socket = Socket::new(addr, libc::SOCK_STREAM)?;
         socket.connect(socket2::SockAddr::from(addr)).await?;

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -47,7 +47,7 @@ impl TcpStream {
     /// result in a successful connection, the error returned from the last
     /// connection attempt (the last address) is returned.
     ///
-    /// [`ToSocketAddrs`]: trait@tokio::net::ToSocketAddrs
+    /// [`ToSocketAddrs`]: trait@std::net::ToSocketAddrs
     pub async fn connect<A: ToSocketAddrs>(addr: A) -> io::Result<TcpStream> {
         let mut sockets = addr.to_socket_addrs()?;
         while let Some(socket_addr) = sockets.next() {

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,5 +1,5 @@
 use std::{io, net::SocketAddr};
-
+use socket2::SockAddr;
 use crate::{
     buf::{IoBuf, IoBufMut},
     driver::Socket,
@@ -100,7 +100,7 @@ impl UdpSocket {
     /// that there is a remote server listening on the port, rather, such an
     /// error would only be detected after the first send.
     pub async fn connect(&self, socket_addr: SocketAddr) -> io::Result<()> {
-        self.inner.connect(socket_addr).await
+        self.inner.connect(SockAddr::from(socket_addr)).await
     }
 
     /// Sends data on the socket to the given address. On success, returns the

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,9 +1,9 @@
-use std::{io, net::SocketAddr};
-use socket2::SockAddr;
 use crate::{
     buf::{IoBuf, IoBufMut},
     driver::Socket,
 };
+use socket2::SockAddr;
+use std::{io, net::SocketAddr};
 
 /// A UDP socket.
 ///

--- a/src/net/unix/listener.rs
+++ b/src/net/unix/listener.rs
@@ -65,7 +65,7 @@ impl UnixListener {
     ///
     /// [`UnixStream`]: struct@crate::net::UnixStream
     pub async fn accept(&self) -> io::Result<UnixStream> {
-        let socket = self.inner.accept_unix().await?;
+        let (socket, _) = self.inner.accept().await?;
         let stream = UnixStream { inner: socket };
         Ok(stream)
     }

--- a/src/net/unix/listener.rs
+++ b/src/net/unix/listener.rs
@@ -1,9 +1,6 @@
 use super::UnixStream;
 use crate::driver::Socket;
-use std::{
-    io,
-    path::Path,
-};
+use std::{io, path::Path};
 
 /// A Unix socket server, listening for connections.
 ///

--- a/src/net/unix/listener.rs
+++ b/src/net/unix/listener.rs
@@ -1,0 +1,64 @@
+use super::UnixStream;
+use crate::driver::Socket;
+use std::{io, path::Path};
+
+/// A Unix socket server, listening for connections.
+///
+/// You can accept a new connection by using the [`accept`](`UnixListener::accept`)
+/// method.
+///
+/// # Examples
+///
+/// ```
+/// use tokio_uring::net::UnixListener;
+/// use tokio_uring::net::UnixStream;
+///
+/// fn main() {
+///     let listener = UnixListener::bind("127.0.0.1:2345".parse().unwrap()).unwrap();
+///
+///     tokio_uring::start(async move {
+///         let tx_fut = UnixStream::connect("127.0.0.1:2345".parse().unwrap());
+///
+///         let rx_fut = listener.accept();
+///
+///         let (tx, (rx, _)) = tokio::try_join!(tx_fut, rx_fut).unwrap();
+///
+///         tx.write(b"test" as &'static [u8]).await.0.unwrap();
+///
+///         let (_, buf) = rx.read(vec![0; 4]).await;
+///
+///         assert_eq!(buf, b"test");
+///     });
+/// }
+/// ```
+pub struct UnixListener {
+    inner: Socket,
+}
+
+impl UnixListener {
+    /// Creates a new UnixListener, which will be bound to the specified address.
+    ///
+    /// The returned listener is ready for accepting connections.
+    ///
+    /// Binding with a port number of 0 will request that the OS assigns a port
+    /// to this listener. The port allocated can be queried via the `local_addr`
+    /// method.
+    pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
+        let socket = Socket::bind_unix(path, libc::SOCK_STREAM)?;
+        socket.listen(1024)?;
+        Ok(UnixListener { inner: socket })
+    }
+
+    /// Accepts a new incoming connection from this listener.
+    ///
+    /// This function will yield once a new TCP connection is established. When
+    /// established, the corresponding [`UnixStream`] and the remote peer's
+    /// address will be returned.
+    ///
+    /// [`UnixStream`]: struct@crate::net::UnixStream
+    pub async fn accept(&self) -> io::Result<UnixStream> {
+        let socket = self.inner.accept_unix().await?;
+        let stream = UnixStream { inner: socket };
+        Ok(stream)
+    }
+}

--- a/src/net/unix/mod.rs
+++ b/src/net/unix/mod.rs
@@ -1,0 +1,5 @@
+mod listener;
+pub use listener::UnixListener;
+
+mod stream;
+pub use stream::UnixStream;

--- a/src/net/unix/stream.rs
+++ b/src/net/unix/stream.rs
@@ -1,9 +1,9 @@
-use std::{io, path::Path};
-use socket2::SockAddr;
 use crate::{
     buf::{IoBuf, IoBufMut},
     driver::Socket,
 };
+use socket2::SockAddr;
+use std::{io, path::Path};
 
 /// A Unix stream between two local sockets on a Unix OS.
 ///
@@ -31,23 +31,16 @@ use crate::{
 /// ```
 ///
 /// [`connect`]: UnixStream::connect
-/// [`accepting`]: crate::net::TcpListener::accept
-/// [`listener`]: crate::net::TcpListener
+/// [`accepting`]: crate::net::UnixListener::accept
+/// [`listener`]: crate::net::UnixListener
 pub struct UnixStream {
     pub(super) inner: Socket,
 }
 
 impl UnixStream {
-    /// Opens a TCP connection to a remote host.
-    ///
-    /// `addr` is an address of the remote host. Anything which implements the
-    /// [`ToSocketAddrs`] trait can be supplied as the address.  If `addr`
-    /// yields multiple addresses, connect will be attempted with each of the
-    /// addresses until a connection is successful. If none of the addresses
-    /// result in a successful connection, the error returned from the last
-    /// connection attempt (the last address) is returned.
-    ///
-    /// [`ToSocketAddrs`]: trait@tokio::net::ToSocketAddrs
+    /// Opens a Unix connection to the specified file path. There must be a
+    /// `UnixListener` or equivalent listening on the corresponding Unix domain socket
+    /// to successfully connect and return a `UnixStream`.
     pub async fn connect<P: AsRef<Path>>(path: P) -> io::Result<UnixStream> {
         let socket = Socket::new_unix(libc::SOCK_STREAM)?;
         socket.connect(SockAddr::unix(path)?).await?;

--- a/src/net/unix/stream.rs
+++ b/src/net/unix/stream.rs
@@ -19,9 +19,7 @@ use crate::{
 /// fn main() -> std::io::Result<()> {
 ///     tokio_uring::start(async {
 ///         // Connect to a peer
-///         let mut stream = UnixStream::connect(
-///             "127.0.0.1:8080".to_socket_addrs().unwrap().next().unwrap()
-///         ).await?;
+///         let mut stream = UnixStream::connect("/tmp/tokio-uring-unix-test.sock").await?;
 ///
 ///         // Write some data.
 ///         let (result, _) = stream.write(b"hello world!".as_slice()).await;

--- a/src/net/unix/stream.rs
+++ b/src/net/unix/stream.rs
@@ -1,5 +1,5 @@
 use std::{io, path::Path};
-
+use socket2::SockAddr;
 use crate::{
     buf::{IoBuf, IoBufMut},
     driver::Socket,
@@ -50,7 +50,7 @@ impl UnixStream {
     /// [`ToSocketAddrs`]: trait@tokio::net::ToSocketAddrs
     pub async fn connect<P: AsRef<Path>>(path: P) -> io::Result<UnixStream> {
         let socket = Socket::new_unix(libc::SOCK_STREAM)?;
-        socket.connect_unix(path).await?;
+        socket.connect(SockAddr::unix(path)?).await?;
         let unix_stream = UnixStream { inner: socket };
         Ok(unix_stream)
     }


### PR DESCRIPTION
Todo: 
- [X] convert all uses of OsSocket to socket2::Socket (to reduce dependencies)

Future:
- Unix datagram

Comments:
- Looking at https://github.com/tokio-rs/tokio-uring/pull/40, apparently I reverted on suggestion not to use `ToSocketAddress`. Personally, I like the use better, and also it is more consistent with tokio API. So I'm proposing to keep this change.