### PR TITLE
`from_std(...)` for UdpSocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 /target
 Cargo.lock
-.idea
-*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+.idea
+*.iml

--- a/src/driver/socket.rs
+++ b/src/driver/socket.rs
@@ -106,6 +106,11 @@ impl Socket {
         Self::bind_internal(addr, libc::AF_UNIX.into(), socket_type.into())
     }
 
+    pub(crate) fn from_std(socket: std::net::UdpSocket) -> Socket {
+        let fd = SharedFd::new(socket.into_raw_fd());
+        Self { fd }
+    }
+
     fn bind_internal(
         socket_addr: socket2::SockAddr,
         domain: socket2::Domain,

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -92,6 +92,62 @@ impl UdpSocket {
         Ok(UdpSocket { inner: socket })
     }
 
+    /// Creates new `UdpSocket` from a previously bound `std::net::UdpSocket`.
+    ///
+    /// This function is intended to be used to wrap a UDP socket from the
+    /// standard library in the Tokio equivalent. The conversion assumes nothing
+    /// about the underlying socket; it is left up to the user to set it in
+    /// non-blocking mode.
+    ///
+    /// This can be used in conjunction with socket2's `Socket` interface to
+    /// configure a socket before it's handed off, such as setting options like
+    /// `reuse_address` or binding to multiple addresses.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use socket2::{Protocol, Socket, Type};
+    /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    /// use tokio_uring::net::UdpSocket;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     tokio_uring::start(async {
+    ///         let std_addr: SocketAddr = "127.0.0.1:2401".parse().unwrap();
+    ///         let second_addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+    ///         let sock = Socket::new(socket2::Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
+    ///         sock.set_reuse_port(true)?;
+    ///         sock.set_nonblocking(true)?;
+    ///         sock.bind(&std_addr.into())?;
+    ///
+    ///         let std_socket = UdpSocket::from_std(sock.into());
+    ///         let other_socket = UdpSocket::bind(second_addr).await?;
+    ///
+    ///         let buf = vec![0; 32];
+    ///
+    ///         // write data
+    ///         let (result, _) = std_socket
+    ///             .send_to(b"hello world".as_slice(), second_addr)
+    ///             .await;
+    ///         result.unwrap();
+    ///
+    ///         // read data
+    ///         let (result, buf) = other_socket.recv_from(buf).await;
+    ///         let (n_bytes, addr) = result.unwrap();
+    ///
+    ///         assert_eq!(addr, std_addr);
+    ///         assert_eq!(b"hello world", &buf[..n_bytes]);
+    ///
+    ///         Ok(())
+    ///     })
+    /// }
+    /// ```
+    pub fn from_std(socket: std::net::UdpSocket) -> UdpSocket {
+        let inner_socket = Socket::from_std(socket);
+        Self {
+            inner: inner_socket,
+        }
+    }
+
     /// Connects this UDP socket to a remote address, allowing the `write` and
     /// `read` syscalls to be used to send data and also applies filters to only
     /// receive data from the specified address.

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -96,8 +96,8 @@ impl UdpSocket {
     ///
     /// This function is intended to be used to wrap a UDP socket from the
     /// standard library in the Tokio equivalent. The conversion assumes nothing
-    /// about the underlying socket; it is left up to the user to set it in
-    /// non-blocking mode.
+    /// about the underlying socket; it is left up to the user to decide what socket
+    /// options are appropriate for their use case.
     ///
     /// This can be used in conjunction with socket2's `Socket` interface to
     /// configure a socket before it's handed off, such as setting options like


### PR DESCRIPTION
I wanted the ability to have finer grained control over which socket options where set when creating a UdpSocket, so implemented a similar API surface to that which exists on `tokio::net::UdpSocket` for the same reason.