### PR TITLE
Implement fs::File::readv_at()/writev_at()

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -14,6 +14,8 @@ mod open;
 
 mod read;
 
+mod readv;
+
 mod recv_from;
 
 mod rename_at;

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -34,6 +34,8 @@ mod util;
 
 mod write;
 
+mod writev;
+
 use io_uring::{cqueue, IoUring};
 use scoped_tls::scoped_thread_local;
 use slab::Slab;

--- a/src/driver/readv.rs
+++ b/src/driver/readv.rs
@@ -1,0 +1,91 @@
+use crate::buf::IoBufMut;
+use crate::driver::{Op, SharedFd};
+use crate::BufResult;
+
+use libc::iovec;
+use std::io;
+use std::task::{Context, Poll};
+
+pub(crate) struct Readv<T> {
+    /// Holds a strong ref to the FD, preventing the file from being closed
+    /// while the operation is in-flight.
+    #[allow(dead_code)]
+    fd: SharedFd,
+
+    /// Reference to the in-flight buffer.
+    pub(crate) bufs: Vec<T>,
+    /// Parameter for `io_uring::op::readv`, referring `bufs`.
+    iovs: Vec<iovec>,
+}
+
+impl<T: IoBufMut> Op<Readv<T>> {
+    pub(crate) fn readv_at(
+        fd: &SharedFd,
+        mut bufs: Vec<T>,
+        offset: u64,
+    ) -> io::Result<Op<Readv<T>>> {
+        use io_uring::{opcode, types};
+
+        // Build `iovec` objects referring the provided `bufs` for `io_uring::opcode::Readv`.
+        let iovs: Vec<iovec> = bufs
+            .iter_mut()
+            .map(|b| iovec {
+                // Safety guaranteed by `IoBufMut`.
+                iov_base: unsafe { b.stable_mut_ptr().add(b.bytes_init()) as *mut libc::c_void },
+                iov_len: b.bytes_total() - b.bytes_init(),
+            })
+            .collect();
+
+        Op::submit_with(
+            Readv {
+                fd: fd.clone(),
+                bufs,
+                iovs,
+            },
+            |read| {
+                opcode::Readv::new(
+                    types::Fd(fd.raw_fd()),
+                    read.iovs.as_ptr(),
+                    read.iovs.len() as u32,
+                )
+                .offset(offset as _)
+                .build()
+            },
+        )
+    }
+
+    pub(crate) async fn readv(mut self) -> BufResult<usize, Vec<T>> {
+        crate::future::poll_fn(move |cx| self.poll_readv(cx)).await
+    }
+
+    pub(crate) fn poll_readv(&mut self, cx: &mut Context<'_>) -> Poll<BufResult<usize, Vec<T>>> {
+        use std::future::Future;
+        use std::pin::Pin;
+
+        let complete = ready!(Pin::new(self).poll(cx));
+
+        // Convert the operation result to `usize`
+        let res = complete.result.map(|v| v as usize);
+        // Recover the buffers
+        let mut bufs = complete.data.bufs;
+
+        // If the operation was successful, advance the initialized cursor.
+        if let Ok(n) = res {
+            let mut count = n;
+            for b in bufs.iter_mut() {
+                let sz = std::cmp::min(count, b.bytes_total() - b.bytes_init());
+                let pos = b.bytes_init() + sz;
+                // Safety: the kernel returns bytes written, and we have ensured that `pos` is
+                // valid for current buffer.
+                unsafe { b.set_init(pos) };
+                count -= sz;
+                if count == 0 {
+                    break;
+                }
+            }
+            assert_eq!(count, 0);
+        }
+
+        Poll::Ready((res, bufs))
+    }
+}

--- a/src/driver/writev.rs
+++ b/src/driver/writev.rs
@@ -1,0 +1,72 @@
+use crate::{
+    buf::IoBuf,
+    driver::{Op, SharedFd},
+    BufResult,
+};
+use libc::iovec;
+use std::{
+    io,
+    task::{Context, Poll},
+};
+
+pub(crate) struct Writev<T> {
+    /// Holds a strong ref to the FD, preventing the file from being closed
+    /// while the operation is in-flight.
+    #[allow(dead_code)]
+    fd: SharedFd,
+
+    pub(crate) bufs: Vec<T>,
+
+    /// Parameter for `io_uring::op::readv`, referring `bufs`.
+    iovs: Vec<iovec>,
+}
+
+impl<T: IoBuf> Op<Writev<T>> {
+    pub(crate) fn writev_at(
+        fd: &SharedFd,
+        mut bufs: Vec<T>,
+        offset: u64,
+    ) -> io::Result<Op<Writev<T>>> {
+        use io_uring::{opcode, types};
+
+        // Build `iovec` objects referring the provided `bufs` for `io_uring::opcode::Readv`.
+        let iovs: Vec<iovec> = bufs
+            .iter_mut()
+            .map(|b| iovec {
+                iov_base: b.stable_ptr() as *mut libc::c_void,
+                iov_len: b.bytes_init(),
+            })
+            .collect();
+
+        Op::submit_with(
+            Writev {
+                fd: fd.clone(),
+                bufs,
+                iovs,
+            },
+            |write| {
+                opcode::Writev::new(
+                    types::Fd(fd.raw_fd()),
+                    write.iovs.as_ptr(),
+                    write.iovs.len() as u32,
+                )
+                .offset(offset as _)
+                .build()
+            },
+        )
+    }
+
+    pub(crate) async fn writev(mut self) -> BufResult<usize, Vec<T>> {
+        use crate::future::poll_fn;
+
+        poll_fn(move |cx| self.poll_writev(cx)).await
+    }
+
+    pub(crate) fn poll_writev(&mut self, cx: &mut Context<'_>) -> Poll<BufResult<usize, Vec<T>>> {
+        use std::future::Future;
+        use std::pin::Pin;
+
+        let complete = ready!(Pin::new(self).poll(cx));
+        Poll::Ready((complete.result.map(|v| v as _), complete.data.bufs))
+    }
+}

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -226,6 +226,62 @@ impl File {
         op.readv().await
     }
 
+    /// Write data from buffers into this file at the specified offset,
+    /// returning how many bytes were written.
+    ///
+    /// This function will attempt to write the entire contents of `bufs`, but
+    /// the entire write may not succeed, or the write may also generate an
+    /// error. The bytes will be written starting at the specified offset.
+    ///
+    /// # Return
+    ///
+    /// The method returns the operation result and the same array of buffers passed
+    /// in as an argument. A return value of `0` typically means that the
+    /// underlying file is no longer able to accept bytes and will likely not be
+    /// able to in the future as well, or that the buffer provided is empty.
+    ///
+    /// # Errors
+    ///
+    /// Each call to `write` may generate an I/O error indicating that the
+    /// operation could not be completed. If an error is returned then no bytes
+    /// in the buffer were written to this writer.
+    ///
+    /// It is **not** considered an error if the entire buffer could not be
+    /// written to this writer.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_uring::fs::File;
+    ///
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     tokio_uring::start(async {
+    ///         let file = File::create("foo.txt").await?;
+    ///
+    ///         // Writes some prefix of the byte string, not necessarily all of it.
+    ///         let bufs = vec!["some".to_owned().into_bytes(), " bytes".to_owned().into_bytes()];
+    ///         let (res, _) = file.writev_at(bufs, 0).await;
+    ///         let n = res?;
+    ///
+    ///         println!("wrote {} bytes", n);
+    ///
+    ///         // Close the file
+    ///         file.close().await?;
+    ///         Ok(())
+    ///     })
+    /// }
+    /// ```
+    ///
+    /// [`Ok(n)`]: Ok
+    pub async fn writev_at<T: IoBuf>(
+        &self,
+        buf: Vec<T>,
+        pos: u64,
+    ) -> crate::BufResult<usize, Vec<T>> {
+        let op = Op::writev_at(&self.fd, buf, pos).unwrap();
+        op.writev().await
+    }
+
     /// Write a buffer into this file at the specified offset, returning how
     /// many bytes were written.
     ///

--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -64,6 +64,23 @@ fn vectored_read() {
 }
 
 #[test]
+fn vectored_write() {
+    tokio_uring::start(async {
+        let tempfile = tempfile();
+
+        let file = File::create(tempfile.path()).await.unwrap();
+        let buf1 = "hello".to_owned().into_bytes();
+        let buf2 = " world...".to_owned().into_bytes();
+        let bufs = vec![buf1, buf2];
+
+        file.writev_at(bufs, 0).await.0.unwrap();
+
+        let file = std::fs::read(tempfile.path()).unwrap();
+        assert_eq!(file, HELLO);
+    });
+}
+
+#[test]
 fn cancel_read() {
     tokio_uring::start(async {
         let mut tempfile = tempfile();

--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -48,6 +48,22 @@ fn basic_write() {
 }
 
 #[test]
+fn vectored_read() {
+    tokio_uring::start(async {
+        let mut tempfile = tempfile();
+        tempfile.write_all(HELLO).unwrap();
+
+        let file = File::open(tempfile.path()).await.unwrap();
+        let bufs = vec![Vec::<u8>::with_capacity(5), Vec::<u8>::with_capacity(9)];
+        let (res, bufs) = file.readv_at(bufs, 0).await;
+        let n = res.unwrap();
+
+        assert_eq!(n, HELLO.len());
+        assert_eq!(bufs[1][0], b' ');
+    });
+}
+
+#[test]
 fn cancel_read() {
     tokio_uring::start(async {
         let mut tempfile = tempfile();


### PR DESCRIPTION
These two methods are very convenient to implement Fuse servers. 
Typical FUSE reply messages are composed up by <COMMON HEADER,  OP HEADER, PAYLOAD DATA>,
writev_at() helps to avoid memory copy operations.