### PR TITLE
fs: implement FromRawFd for File

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -4,7 +4,7 @@ use crate::fs::OpenOptions;
 
 use std::fmt;
 use std::io;
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::Path;
 
 /// A reference to an open file on the filesystem.
@@ -327,6 +327,12 @@ impl File {
     pub async fn close(self) -> io::Result<()> {
         self.fd.close().await;
         Ok(())
+    }
+}
+
+impl FromRawFd for File {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        File::from_shared_fd(SharedFd::new(fd))
     }
 }
 


### PR DESCRIPTION
Implement FromRawFd for File, so we could convert a normal file into
tokio-uring File.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>