### PR TITLE
fs: implement `rename`

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -16,6 +16,8 @@ mod read;
 
 mod recv_from;
 
+mod rename_at;
+
 mod send_to;
 
 mod shared_fd;

--- a/src/driver/rename_at.rs
+++ b/src/driver/rename_at.rs
@@ -1,0 +1,40 @@
+use crate::driver::{self, Op};
+
+use std::ffi::CString;
+use std::io;
+use std::path::Path;
+
+/// Renames a file, moving it between directories if required.
+/// The given paths are interpreted relative to the current working directory
+/// of the calling process.
+pub(crate) struct RenameAt {
+    pub(crate) from: CString,
+    pub(crate) to: CString,
+}
+
+impl Op<RenameAt> {
+    /// Submit a request to rename a specified path to a new name with
+    /// the provided flags.
+    pub(crate) fn rename_at(from: &Path, to: &Path, flags: u32) -> io::Result<Op<RenameAt>> {
+        use io_uring::{opcode, types};
+
+        let from = driver::util::cstr(from)?;
+        let to = driver::util::cstr(to)?;
+
+        Op::submit_with(RenameAt { from, to }, |rename| {
+            // Get a reference to the memory. The string will be held by the
+            // operation state and will not be accessed again until the operation
+            // completes.
+            let from_ref = rename.from.as_c_str().as_ptr();
+            let to_ref = rename.to.as_c_str().as_ptr();
+            opcode::RenameAt::new(
+                types::Fd(libc::AT_FDCWD),
+                from_ref,
+                types::Fd(libc::AT_FDCWD),
+                to_ref,
+            )
+            .flags(flags)
+            .build()
+        })
+    }
+}

--- a/src/driver/rename_at.rs
+++ b/src/driver/rename_at.rs
@@ -5,6 +5,7 @@ use std::io;
 use std::path::Path;
 
 /// Renames a file, moving it between directories if required.
+///
 /// The given paths are interpreted relative to the current working directory
 /// of the calling process.
 pub(crate) struct RenameAt {

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -368,3 +368,28 @@ impl fmt::Debug for File {
 pub async fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
     Op::unlink_file(path.as_ref())?.await.result.map(|_| ())
 }
+
+/// Renames a file or directory to a new name, replacing the original file if
+/// `to` already exists.
+///
+/// This will not work if the new name is on a different mount point.
+///
+/// # Example
+///
+/// ```no_run
+/// use tokio_uring::fs::rename;
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     tokio_uring::start(async {
+///         rename("a.txt", "b.txt").await?; // Rename a.txt to b.txt
+///         Ok::<(), std::io::Error>(())
+///     })?;
+///     Ok(())
+/// }
+/// ```
+pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> {
+    Op::rename_at(from.as_ref(), to.as_ref(), 0)?
+        .await
+        .result
+        .map(|_| ())
+}

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -5,6 +5,7 @@ pub use directory::remove_dir;
 
 mod file;
 pub use file::remove_file;
+pub use file::rename;
 pub use file::File;
 
 mod open_options;


### PR DESCRIPTION
Implement the `rename` operation for `fs`.
This operation uses [`IORING_OP_RENAMEAT`](https://man.archlinux.org/man/io_uring_enter.2.en#IORING_OP_RENAMEAT) as the opcode for the submitted
SQE.

Both file descriptors are set to the special value `AT_FDCWD` so that
the given paths are interpreted relative to the current working
directory of the calling process. [[1]](#1)

The operation is submitted with a zero `flags` argument so that it would
be equivalent to the corresponding operation in [`tokio:fs`](https://docs.rs/tokio/latest/tokio/fs/fn.rename.html)/[`std:fs`](https://doc.rust-lang.org/std/fs/fn.rename.html). [[1]](#1)

Refs: #48

<a id="1">[1]</a> [`renameat2` syscall man page](https://man7.org/linux/man-pages/man2/renameat2.2.html)