### PR TITLE
chore: add all-systems-go ci check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,18 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  # Depends on all actions that are required for a "successful" CI run.
+  # Based on the ci here: https://github.com/tokio-rs/tokio/blob/master/.github/workflows/ci.yml
+  all-systems-go:
+    runs-on: ubuntu-latest
+    needs:
+      - check
+      - fmt
+      - test
+      - docs
+    steps:
+      - run: exit 0
+
   check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add a CI check which passes as soon as all required checks do. This allows us to set one required status check.