### PR TITLE
net: add TcpListener.local_addr method

### DIFF
--- a/examples/tcp_listener.rs
+++ b/examples/tcp_listener.rs
@@ -14,6 +14,8 @@ fn main() {
     tokio_uring::start(async {
         let listener = TcpListener::bind(socket_addr).unwrap();
 
+        println!("Listening on {}", listener.local_addr().unwrap());
+
         loop {
             let (stream, socket_addr) = listener.accept().await.unwrap();
             tokio_uring::spawn(async move {

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -48,9 +48,8 @@ impl TcpListener {
 
     /// Returns the local address that this listener is bound to.
     ///
-    /// This can be useful, for example, when binding to port 0 to figure out
-    /// which port was actually bound. The implementation relies on the standard net
-    /// system call so is blocking.
+    /// This can be useful, for example, when binding to port 0 to
+    /// figure out which port was actually bound.
     ///
     /// # Examples
     ///
@@ -63,7 +62,6 @@ impl TcpListener {
     /// let addr = listener.local_addr().expect("Couldn't get local address");
     /// assert_eq!(addr, SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080)));
     /// ```
-    #[cfg(unix)]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         use std::os::unix::io::{AsRawFd, FromRawFd};
 

--- a/src/net/unix/listener.rs
+++ b/src/net/unix/listener.rs
@@ -45,6 +45,35 @@ impl UnixListener {
         Ok(UnixListener { inner: socket })
     }
 
+    /// Returns the local address that this listener is bound to.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio_uring::net::UnixListener;
+    /// use std::path::Path;
+    ///
+    /// let sock_file = "/tmp/tokio-uring-unix-test.sock";
+    /// let listener = UnixListener::bind(&sock_file).unwrap();
+    ///
+    /// let addr = listener.local_addr().expect("Couldn't get local address");
+    /// assert_eq!(addr.as_pathname(), Some(Path::new(sock_file)));
+    ///
+    /// std::fs::remove_file(&sock_file).unwrap();
+    /// ```
+    pub fn local_addr(&self) -> io::Result<std::os::unix::net::SocketAddr> {
+        use std::os::unix::io::{AsRawFd, FromRawFd};
+
+        let fd = self.inner.as_raw_fd();
+        // SAFETY: Our fd is the handle the kernel has given us for a UnixListener.
+        // Create a std::net::UnixListener long enough to call its local_addr method
+        // and then forget it so the socket is not closed here.
+        let l = unsafe { std::os::unix::net::UnixListener::from_raw_fd(fd) };
+        let local_addr = l.local_addr();
+        std::mem::forget(l);
+        local_addr
+    }
+
     /// Accepts a new incoming connection from this listener.
     ///
     /// This function will yield once a new Unix domain socket connection


### PR DESCRIPTION
The local_addr method is a blocking call.