### PR TITLE
io: refactor post-op logic in ops into Completable

### DIFF
--- a/src/driver/close.rs
+++ b/src/driver/close.rs
@@ -1,5 +1,6 @@
 use crate::driver::Op;
 
+use crate::driver::op::Completable;
 use std::io;
 use std::os::unix::io::RawFd;
 
@@ -14,5 +15,15 @@ impl Op<Close> {
         Op::try_submit_with(Close { fd }, |close| {
             opcode::Close::new(types::Fd(close.fd)).build()
         })
+    }
+}
+
+impl Completable for Close {
+    type Output = io::Result<()>;
+
+    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
+        let _ = result?;
+
+        Ok(())
     }
 }

--- a/src/driver/connect.rs
+++ b/src/driver/connect.rs
@@ -1,3 +1,4 @@
+use crate::driver::op::Completable;
 use crate::driver::{Op, SharedFd};
 use socket2::SockAddr;
 use std::io;
@@ -27,5 +28,13 @@ impl Op<Connect> {
                 .build()
             },
         )
+    }
+}
+
+impl Completable for Connect {
+    type Output = io::Result<()>;
+
+    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
+        result.map(|_| ())
     }
 }

--- a/src/driver/fsync.rs
+++ b/src/driver/fsync.rs
@@ -2,6 +2,7 @@ use crate::driver::{Op, SharedFd};
 
 use std::io;
 
+use crate::driver::op::Completable;
 use io_uring::{opcode, types};
 
 pub(crate) struct Fsync {
@@ -21,5 +22,13 @@ impl Op<Fsync> {
                 .flags(types::FsyncFlags::DATASYNC)
                 .build()
         })
+    }
+}
+
+impl Completable for Fsync {
+    type Output = io::Result<()>;
+
+    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
+        result.map(|_| ())
     }
 }

--- a/src/driver/op.rs
+++ b/src/driver/op.rs
@@ -21,14 +21,9 @@ pub(crate) struct Op<T: 'static> {
     data: Option<T>,
 }
 
-/// Operation completion. Returns stored state with the result of the operation.
-#[derive(Debug)]
-pub(crate) struct Completion<T> {
-    pub(crate) data: T,
-    pub(crate) result: io::Result<u32>,
-    // the field is currently only read in tests
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) flags: u32,
+pub(crate) trait Completable {
+    type Output;
+    fn complete(self, result: io::Result<u32>, flags: u32) -> Self::Output;
 }
 
 pub(crate) enum Lifecycle {
@@ -46,7 +41,10 @@ pub(crate) enum Lifecycle {
     Completed(io::Result<u32>, u32),
 }
 
-impl<T> Op<T> {
+impl<T> Op<T>
+where
+    T: Completable,
+{
     /// Create a new operation
     fn new(data: T, inner: &mut driver::Inner, inner_rc: &Rc<RefCell<driver::Inner>>) -> Op<T> {
         Op {
@@ -107,9 +105,9 @@ impl<T> Op<T> {
 
 impl<T> Future for Op<T>
 where
-    T: Unpin + 'static,
+    T: Unpin + 'static + Completable,
 {
-    type Output = Completion<T>;
+    type Output = T::Output;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         use std::mem;
@@ -136,11 +134,7 @@ where
                 inner.ops.remove(me.index);
                 me.index = usize::MAX;
 
-                Poll::Ready(Completion {
-                    data: me.data.take().expect("unexpected operation state"),
-                    result,
-                    flags,
-                })
+                Poll::Ready(me.data.take().unwrap().complete(result, flags))
             }
         }
     }
@@ -193,6 +187,25 @@ mod test {
     use tokio_test::{assert_pending, assert_ready, task};
 
     use super::*;
+
+    #[derive(Debug)]
+    pub(crate) struct Completion {
+        result: io::Result<u32>,
+        flags: u32,
+        data: Rc<()>,
+    }
+
+    impl Completable for Rc<()> {
+        type Output = Completion;
+
+        fn complete(self, result: io::Result<u32>, flags: u32) -> Self::Output {
+            Completion {
+                result,
+                flags,
+                data: self.clone(),
+            }
+        }
+    }
 
     #[test]
     fn op_stays_in_slab_on_drop() {

--- a/src/driver/open.rs
+++ b/src/driver/open.rs
@@ -1,6 +1,7 @@
-use crate::driver::{self, Op};
-use crate::fs::OpenOptions;
+use crate::driver::{self, Op, SharedFd};
+use crate::fs::{File, OpenOptions};
 
+use crate::driver::op::Completable;
 use std::ffi::CString;
 use std::io;
 use std::path::Path;
@@ -30,5 +31,13 @@ impl Op<Open> {
                 .mode(options.mode)
                 .build()
         })
+    }
+}
+
+impl Completable for Open {
+    type Output = io::Result<File>;
+
+    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
+        Ok(File::from_shared_fd(SharedFd::new(result? as _)))
     }
 }

--- a/src/driver/rename_at.rs
+++ b/src/driver/rename_at.rs
@@ -1,5 +1,6 @@
 use crate::driver::{self, Op};
 
+use crate::driver::op::Completable;
 use std::ffi::CString;
 use std::io;
 use std::path::Path;
@@ -37,5 +38,13 @@ impl Op<RenameAt> {
             .flags(flags)
             .build()
         })
+    }
+}
+
+impl Completable for RenameAt {
+    type Output = io::Result<()>;
+
+    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
+        result.map(|_| ())
     }
 }

--- a/src/driver/unlink_at.rs
+++ b/src/driver/unlink_at.rs
@@ -1,5 +1,6 @@
 use crate::driver::{self, Op};
 
+use crate::driver::op::Completable;
 use std::ffi::CString;
 use std::io;
 use std::path::Path;
@@ -35,5 +36,13 @@ impl Op<Unlink> {
                 .flags(flags)
                 .build()
         })
+    }
+}
+
+impl Completable for Unlink {
+    type Output = io::Result<()>;
+
+    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
+        result.map(|_| ())
     }
 }

--- a/src/driver/write.rs
+++ b/src/driver/write.rs
@@ -1,3 +1,4 @@
+use crate::driver::op::Completable;
 use crate::{
     buf::IoBuf,
     driver::{Op, SharedFd},
@@ -49,6 +50,22 @@ impl<T: IoBuf> Op<Write<T>> {
         use std::pin::Pin;
 
         let complete = ready!(Pin::new(self).poll(cx));
-        Poll::Ready((complete.result.map(|v| v as _), complete.data.buf))
+        Poll::Ready(complete)
+    }
+}
+
+impl<T> Completable for Write<T>
+where
+    T: IoBuf,
+{
+    type Output = BufResult<usize, T>;
+
+    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
+        // Convert the operation result to `usize`
+        let res = result.map(|v| v as usize);
+        // Recover the buffer
+        let buf = self.buf;
+
+        (res, buf)
     }
 }

--- a/src/fs/directory.rs
+++ b/src/fs/directory.rs
@@ -19,9 +19,5 @@ use std::path::Path;
 /// }
 /// ```
 pub async fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    let op = Op::unlink_dir(path.as_ref())?;
-    let completion = op.await;
-    completion.result?;
-
-    Ok(())
+    Op::unlink_dir(path.as_ref())?.await
 }

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -362,11 +362,7 @@ impl File {
     /// }
     /// ```
     pub async fn sync_all(&self) -> io::Result<()> {
-        let op = Op::fsync(&self.fd).unwrap();
-        let completion = op.await;
-
-        completion.result?;
-        Ok(())
+        Op::fsync(&self.fd)?.await
     }
 
     /// Attempts to sync file data to disk.
@@ -403,11 +399,7 @@ impl File {
     /// }
     /// ```
     pub async fn sync_data(&self) -> io::Result<()> {
-        let op = Op::datasync(&self.fd).unwrap();
-        let completion = op.await;
-
-        completion.result?;
-        Ok(())
+        Op::datasync(&self.fd)?.await
     }
 
     /// Closes the file.
@@ -477,7 +469,7 @@ impl fmt::Debug for File {
 /// }
 /// ```
 pub async fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    Op::unlink_file(path.as_ref())?.await.result.map(|_| ())
+    Op::unlink_file(path.as_ref())?.await
 }
 
 /// Renames a file or directory to a new name, replacing the original file if
@@ -499,8 +491,5 @@ pub async fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// }
 /// ```
 pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> {
-    Op::rename_at(from.as_ref(), to.as_ref(), 0)?
-        .await
-        .result
-        .map(|_| ())
+    Op::rename_at(from.as_ref(), to.as_ref(), 0)?.await
 }

--- a/src/fs/open_options.rs
+++ b/src/fs/open_options.rs
@@ -1,4 +1,4 @@
-use crate::driver::{Op, SharedFd};
+use crate::driver::Op;
 use crate::fs::File;
 
 use std::io;
@@ -330,13 +330,7 @@ impl OpenOptions {
     /// [`Other`]: io::ErrorKind::Other
     /// [`PermissionDenied`]: io::ErrorKind::PermissionDenied
     pub async fn open(&self, path: impl AsRef<Path>) -> io::Result<File> {
-        let op = Op::open(path.as_ref(), self)?;
-
-        // Await the completion of the event
-        let completion = op.await;
-
-        // The file is open
-        Ok(File::from_shared_fd(SharedFd::new(completion.result? as _)))
+        Op::open(path.as_ref(), self)?.await
     }
 
     pub(crate) fn access_mode(&self) -> io::Result<libc::c_int> {


### PR DESCRIPTION
As a first step towards implementing cancellation of in-flight operations, we need to move the post-op logic into the scope of Op so that we can eventually expose that directly instead of hiding it within async blocks. This will allow us to expose a public, async cancel method on it which cancels the in-flight op and awaits its termination.