### PR TITLE
Fix network doc examples

### DIFF
--- a/src/net/unix/listener.rs
+++ b/src/net/unix/listener.rs
@@ -17,11 +17,18 @@ use std::{io, path::Path};
 /// let listener = UnixListener::bind(&sock_file).unwrap();
 ///
 /// tokio_uring::start(async move {
-///     let tx_fut = UnixStream::connect(&sock_file);
+///     let (tx_ch, rx_ch) = tokio::sync::oneshot::channel();
 ///
-///     let rx_fut = listener.accept();
+///     tokio_uring::spawn(async move {
+///         let rx = listener.accept().await.unwrap();
+///         if let Err(_) = tx_ch.send(rx) {
+///             panic!("The receiver dropped");
+///         }
+///     });
+///     tokio::task::yield_now().await; // Ensure the listener.accept().await has been kicked off.
 ///
-///     let (tx, rx) = tokio::try_join!(tx_fut, rx_fut).unwrap();
+///     let tx = UnixStream::connect(&sock_file).await.unwrap();
+///     let rx = rx_ch.await.expect("The spawned task expected to send a UnixStream");
 ///
 ///     tx.write(b"test" as &'static [u8]).await.0.unwrap();
 ///


### PR DESCRIPTION
Two places try_join! was used to have a socket accept and a socket connect performed concurrently.

But if the socket connect were tried first, it can fail because there was no accepting socket to connect with.

This attempts to fix that by getting the socket accept run before the socket connect is attempted.

There may still be the potential for a race because the asynchronous socket accept operation
only ensures the uring sqe entry is created, it does not actually get the kernel started on the operation. The driver in this crate only informs the kernel of sqe entries when the *on_thread_park* callback is run and it is possible both the async accept and the async connect will be placed in the uring sq and only then will the on_thread_park callback be run and the kernel makes no promises which sqe operation will be completed first when it finds multiple entries but for now, it seems reasonable to assume the kernel tries initiating the operations in the order it finds them and that may be enough.

If this does become a problem again, a very short sleep in place of the a yield_now should be enough to ensure the accept operation has been started first.

Fixes #117.