### PR TITLE
Support multi completion events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ libc = "0.2.80"
 io-uring = { version = "0.5.0", features = [ "unstable" ] }
 socket2 = { version = "0.4.4", features = [ "all"] }
 bytes = { version = "1.0", optional = true }
+smallvec = "1.10.0"
 
 [dev-dependencies]
 bencher = "0.1.5"

--- a/src/driver/op.rs
+++ b/src/driver/op.rs
@@ -65,7 +65,7 @@ pub(crate) enum Lifecycle {
     /// The operation has 1 or more unserviced completion events, and poll has yet to be called
     ///
     /// This allocates if more than the default number of completions (currently 4)
-    /// Are received before poll is invoked
+    /// are received before poll is invoked
     Completed(SmallVec<[(io::Result<u32>, u32); 4]>),
 }
 


### PR DESCRIPTION
Support of multi completion events, originally proposed in https://github.com/tokio-rs/tokio-uring/pull/123, and submitted separately for review as suggested by @Noah-Kennedy 

Multi completion events contain a `CQE_F_MORE` flag, which indicates more events are expected associated with the same submission entry. This leads to a 1:M correspondance, where all ops currently supported are 1:1

This PR modifies `struct Op<T>` to support both types. It does this by adding the `update`  method to the Completable trait. The semantics of this are:
  
> Take 1 or more completions, _update_ the state of the operation, and return if the operation is `Finished`, with the result, or if `More` are required

For single event Ops, the result will always be `Finished`. As this is the most likely behaviour, the default method is provided. 

To support this with the current Lifecycle handling, the `Lifecycle::Completed` variant now contains 1 or more completions, rather than 1. This is because there is a data race between reading the completion queue, and operations calling `poll()` to consume `Lifecycle::Completed`. To manage this, completions are stored in a growable conatiner. `smallvec` (a vec with small string optimization) has been chosen to avoid allocations in the vast majority of cases. The default size is chosen to be small (under a cache line), by no rigorous method. It may want to be bigger (8 or 16).

Other changes to Lifecycle include the Ignored variant. This now has to wait for _all_ outstanding completions for an Op before being dropped. It just checks the more flag to do this.

There are design decisions here which want discussing. 

The major one in my eyes is the decision to have an unbounded collection of completion events. The other option would be to stall the completion queue handling once some predetermined threshold of completion events for a single op is reached. A waker would be registered, and completion queue handling would be woken when the Lifecycle::Completed was consumed by the Op's Poll(). I deemed this unpalatable, as it stalls all Ops