### PR TITLE
fs: implement OpenOptionsExt for OpenOptions

### DIFF
--- a/src/driver/open.rs
+++ b/src/driver/open.rs
@@ -18,7 +18,10 @@ impl Op<Open> {
     pub(crate) fn open(path: &Path, options: &OpenOptions) -> io::Result<Op<Open>> {
         use io_uring::{opcode, types};
         let path = driver::util::cstr(path)?;
-        let flags = libc::O_CLOEXEC | options.access_mode()? | options.creation_mode()?;
+        let flags = libc::O_CLOEXEC
+            | options.access_mode()?
+            | options.creation_mode()?
+            | (options.custom_flags & !libc::O_ACCMODE);
 
         Op::submit_with(Open { path, flags }, |open| {
             // Get a reference to the memory. The string will be held by the

--- a/src/fs/open_options.rs
+++ b/src/fs/open_options.rs
@@ -2,6 +2,7 @@ use crate::driver::Op;
 use crate::fs::File;
 
 use std::io;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 
 /// Options and flags which can be used to configure how a file is opened.
@@ -62,6 +63,7 @@ pub struct OpenOptions {
     create: bool,
     create_new: bool,
     pub(crate) mode: libc::mode_t,
+    pub(crate) custom_flags: libc::c_int,
 }
 
 impl OpenOptions {
@@ -94,6 +96,7 @@ impl OpenOptions {
             create: false,
             create_new: false,
             mode: 0o666,
+            custom_flags: 0,
         }
     }
 
@@ -372,5 +375,17 @@ impl OpenOptions {
 impl Default for OpenOptions {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl OpenOptionsExt for OpenOptions {
+    fn mode(&mut self, mode: u32) -> &mut OpenOptions {
+        self.mode = mode;
+        self
+    }
+
+    fn custom_flags(&mut self, flags: i32) -> &mut OpenOptions {
+        self.custom_flags = flags;
+        self
     }
 }


### PR DESCRIPTION
Implements `mode()` and `custom_flags()` of `std::os::unix::fs::OpenOptionsExt` for `OpenOptions`. 
`custom_flags` are masked out with `O_ACCMODE`.

Fixes https://github.com/tokio-rs/tokio-uring/issues/108