### PR TITLE
Add NoOp support

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -7,6 +7,9 @@ mod connect;
 
 mod fsync;
 
+mod noop;
+pub(crate) use noop::NoOp;
+
 mod op;
 pub(crate) use op::Op;
 

--- a/src/driver/noop.rs
+++ b/src/driver/noop.rs
@@ -1,0 +1,28 @@
+use crate::driver::{Op,op::Completable};
+use std::io;
+
+/// No operation. Just posts a completion event, nothing else.
+///
+/// Has a place in benchmarking.
+pub struct NoOp {}
+
+impl Op<NoOp> {
+    pub fn no_op() -> io::Result<Op<NoOp>> {
+        use io_uring::{opcode};
+
+        Op::submit_with(
+            NoOp {},
+            |_| {
+                opcode::Nop::new().build()
+            },
+        )
+    }
+}
+
+impl Completable for NoOp {
+    type Output = io::Result<()>;
+
+    fn complete(self, _result: io::Result<u32>, _flags: u32) -> Self::Output {
+        Ok(())
+    }
+}

--- a/src/driver/noop.rs
+++ b/src/driver/noop.rs
@@ -21,3 +21,15 @@ impl Completable for NoOp {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate as tokio_uring;
+
+    #[test]
+    fn perform_no_op() -> () {
+        tokio_uring::start(async {
+            tokio_uring::no_op().await.unwrap();
+        })
+    }
+}

--- a/src/driver/noop.rs
+++ b/src/driver/noop.rs
@@ -1,4 +1,4 @@
-use crate::driver::{Op,op::Completable};
+use crate::driver::{op::Completable, Op};
 use std::io;
 
 /// No operation. Just posts a completion event, nothing else.
@@ -8,14 +8,9 @@ pub struct NoOp {}
 
 impl Op<NoOp> {
     pub fn no_op() -> io::Result<Op<NoOp>> {
-        use io_uring::{opcode};
+        use io_uring::opcode;
 
-        Op::submit_with(
-            NoOp {},
-            |_| {
-                opcode::Nop::new().build()
-            },
-        )
+        Op::submit_with(NoOp {}, |_| opcode::Nop::new().build())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,7 @@ pub type BufResult<T, B> = (std::io::Result<T>, B);
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     tokio_uring::start(async {
 ///         // Place a NoOp on the ring, and await completion event
-///         no_op()?;
+///         tokio_uring::no_op().await?;
 ///         Ok(())
 ///     })
 /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,3 +262,23 @@ impl Builder {
 /// }
 /// ```
 pub type BufResult<T, B> = (std::io::Result<T>, B);
+
+/// The simplest possible operation. Just posts a completion event, nothing else.
+///
+/// This has a place in benchmarking and sanity checking uring.
+///
+/// # Examples
+///
+/// ```no_run
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     tokio_uring::start(async {
+///         // Place a NoOp on the ring, and await completion event
+///         no_op()?;
+///         Ok(())
+///     })
+/// }
+/// ```
+pub async fn no_op() -> std::io::Result<()> {
+    let op = driver::Op::<driver::NoOp>::no_op().unwrap();
+    op.await
+}


### PR DESCRIPTION
Adds support for the NoOp (no-operation) operation. This does nothing except await a completion.

I'm trying to understand the performance aspects of various bits of my system, and understanding the runtime overhead is useful. This makes that a lot easier.

It doesn't clearly fall into `fs`, `net`, or `buf`, so I've placed it at the top level.