### PR TITLE
simplify driver operation futures

### DIFF
--- a/src/driver/read.rs
+++ b/src/driver/read.rs
@@ -4,7 +4,6 @@ use crate::BufResult;
 
 use crate::driver::op::Completable;
 use std::io;
-use std::task::{Context, Poll};
 
 pub(crate) struct Read<T> {
     /// Holds a strong ref to the FD, preventing the file from being closed
@@ -34,19 +33,6 @@ impl<T: IoBufMut> Op<Read<T>> {
                     .build()
             },
         )
-    }
-
-    pub(crate) async fn read(mut self) -> BufResult<usize, T> {
-        crate::future::poll_fn(move |cx| self.poll_read(cx)).await
-    }
-
-    pub(crate) fn poll_read(&mut self, cx: &mut Context<'_>) -> Poll<BufResult<usize, T>> {
-        use std::future::Future;
-        use std::pin::Pin;
-
-        let complete = ready!(Pin::new(self).poll(cx));
-
-        Poll::Ready(complete)
     }
 }
 

--- a/src/driver/readv.rs
+++ b/src/driver/readv.rs
@@ -5,7 +5,6 @@ use crate::BufResult;
 use crate::driver::op::Completable;
 use libc::iovec;
 use std::io;
-use std::task::{Context, Poll};
 
 pub(crate) struct Readv<T> {
     /// Holds a strong ref to the FD, preventing the file from being closed
@@ -53,19 +52,6 @@ impl<T: IoBufMut> Op<Readv<T>> {
                 .build()
             },
         )
-    }
-
-    pub(crate) async fn readv(mut self) -> BufResult<usize, Vec<T>> {
-        crate::future::poll_fn(move |cx| self.poll_readv(cx)).await
-    }
-
-    pub(crate) fn poll_readv(&mut self, cx: &mut Context<'_>) -> Poll<BufResult<usize, Vec<T>>> {
-        use std::future::Future;
-        use std::pin::Pin;
-
-        let complete = ready!(Pin::new(self).poll(cx));
-
-        Poll::Ready(complete)
     }
 }
 

--- a/src/driver/recv_from.rs
+++ b/src/driver/recv_from.rs
@@ -7,7 +7,6 @@ use crate::{
 use socket2::SockAddr;
 use std::{
     io::IoSliceMut,
-    task::{Context, Poll},
     {boxed::Box, io, net::SocketAddr},
 };
 
@@ -52,24 +51,6 @@ impl<T: IoBufMut> Op<RecvFrom<T>> {
                 .build()
             },
         )
-    }
-
-    pub(crate) async fn recv(mut self) -> BufResult<(usize, SocketAddr), T> {
-        use crate::future::poll_fn;
-
-        poll_fn(move |cx| self.poll_recv_from(cx)).await
-    }
-
-    pub(crate) fn poll_recv_from(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<BufResult<(usize, SocketAddr), T>> {
-        use std::future::Future;
-        use std::pin::Pin;
-
-        let complete = ready!(Pin::new(self).poll(cx));
-
-        Poll::Ready(complete)
     }
 }
 

--- a/src/driver/send_to.rs
+++ b/src/driver/send_to.rs
@@ -4,7 +4,6 @@ use crate::driver::{Op, SharedFd};
 use crate::BufResult;
 use socket2::SockAddr;
 use std::io::IoSlice;
-use std::task::{Context, Poll};
 use std::{boxed::Box, io, net::SocketAddr};
 
 pub(crate) struct SendTo<T> {
@@ -54,20 +53,6 @@ impl<T: IoBuf> Op<SendTo<T>> {
                 .build()
             },
         )
-    }
-
-    pub(crate) async fn send(mut self) -> BufResult<usize, T> {
-        use crate::future::poll_fn;
-
-        poll_fn(move |cx| self.poll_send(cx)).await
-    }
-
-    pub(crate) fn poll_send(&mut self, cx: &mut Context<'_>) -> Poll<BufResult<usize, T>> {
-        use std::future::Future;
-        use std::pin::Pin;
-
-        let complete = ready!(Pin::new(self).poll(cx));
-        Poll::Ready(complete)
     }
 }
 

--- a/src/driver/socket.rs
+++ b/src/driver/socket.rs
@@ -41,7 +41,7 @@ impl Socket {
 
     pub(crate) async fn write<T: IoBuf>(&self, buf: T) -> crate::BufResult<usize, T> {
         let op = Op::write_at(&self.fd, buf, 0).unwrap();
-        op.write().await
+        op.await
     }
 
     pub(crate) async fn send_to<T: IoBuf>(
@@ -50,12 +50,12 @@ impl Socket {
         socket_addr: SocketAddr,
     ) -> crate::BufResult<usize, T> {
         let op = Op::send_to(&self.fd, buf, socket_addr).unwrap();
-        op.send().await
+        op.await
     }
 
     pub(crate) async fn read<T: IoBufMut>(&self, buf: T) -> crate::BufResult<usize, T> {
         let op = Op::read_at(&self.fd, buf, 0).unwrap();
-        op.read().await
+        op.await
     }
 
     pub(crate) async fn recv_from<T: IoBufMut>(
@@ -63,7 +63,7 @@ impl Socket {
         buf: T,
     ) -> crate::BufResult<(usize, SocketAddr), T> {
         let op = Op::recv_from(&self.fd, buf).unwrap();
-        op.recv().await
+        op.await
     }
 
     pub(crate) async fn accept(&self) -> io::Result<(Socket, Option<SocketAddr>)> {

--- a/src/driver/write.rs
+++ b/src/driver/write.rs
@@ -4,10 +4,7 @@ use crate::{
     driver::{Op, SharedFd},
     BufResult,
 };
-use std::{
-    io,
-    task::{Context, Poll},
-};
+use std::io;
 
 pub(crate) struct Write<T> {
     /// Holds a strong ref to the FD, preventing the file from being closed
@@ -37,20 +34,6 @@ impl<T: IoBuf> Op<Write<T>> {
                     .build()
             },
         )
-    }
-
-    pub(crate) async fn write(mut self) -> BufResult<usize, T> {
-        use crate::future::poll_fn;
-
-        poll_fn(move |cx| self.poll_write(cx)).await
-    }
-
-    pub(crate) fn poll_write(&mut self, cx: &mut Context<'_>) -> Poll<BufResult<usize, T>> {
-        use std::future::Future;
-        use std::pin::Pin;
-
-        let complete = ready!(Pin::new(self).poll(cx));
-        Poll::Ready(complete)
     }
 }
 

--- a/src/driver/writev.rs
+++ b/src/driver/writev.rs
@@ -5,10 +5,7 @@ use crate::{
     BufResult,
 };
 use libc::iovec;
-use std::{
-    io,
-    task::{Context, Poll},
-};
+use std::io;
 
 pub(crate) struct Writev<T> {
     /// Holds a strong ref to the FD, preventing the file from being closed
@@ -55,20 +52,6 @@ impl<T: IoBuf> Op<Writev<T>> {
                 .build()
             },
         )
-    }
-
-    pub(crate) async fn writev(mut self) -> BufResult<usize, Vec<T>> {
-        use crate::future::poll_fn;
-
-        poll_fn(move |cx| self.poll_writev(cx)).await
-    }
-
-    pub(crate) fn poll_writev(&mut self, cx: &mut Context<'_>) -> Poll<BufResult<usize, Vec<T>>> {
-        use std::future::Future;
-        use std::pin::Pin;
-
-        let complete = ready!(Pin::new(self).poll(cx));
-        Poll::Ready(complete)
     }
 }
 

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -176,7 +176,7 @@ impl File {
     pub async fn read_at<T: IoBufMut>(&self, buf: T, pos: u64) -> crate::BufResult<usize, T> {
         // Submit the read operation
         let op = Op::read_at(&self.fd, buf, pos).unwrap();
-        op.read().await
+        op.await
     }
 
     /// Read some bytes at the specified offset from the file into the specified
@@ -231,7 +231,7 @@ impl File {
     ) -> crate::BufResult<usize, Vec<T>> {
         // Submit the read operation
         let op = Op::readv_at(&self.fd, bufs, pos).unwrap();
-        op.readv().await
+        op.await
     }
 
     /// Write data from buffers into this file at the specified offset,
@@ -287,7 +287,7 @@ impl File {
         pos: u64,
     ) -> crate::BufResult<usize, Vec<T>> {
         let op = Op::writev_at(&self.fd, buf, pos).unwrap();
-        op.writev().await
+        op.await
     }
 
     /// Write a buffer into this file at the specified offset, returning how
@@ -338,7 +338,7 @@ impl File {
     /// [`Ok(n)`]: Ok
     pub async fn write_at<T: IoBuf>(&self, buf: T, pos: u64) -> crate::BufResult<usize, T> {
         let op = Op::write_at(&self.fd, buf, pos).unwrap();
-        op.write().await
+        op.await
     }
 
     /// Attempts to sync all OS-internal metadata to disk.


### PR DESCRIPTION
These functions being unnecessary is probably the result of the recent introduction of the Completable trait. By definition, all the specific work to create a driver operation's results given the cqe data is done by the complete function now.

Addresses #137.