### PR TITLE
sync TcpStream, UnixStream and UdpSocket functionality

### DIFF
--- a/src/driver/socket.rs
+++ b/src/driver/socket.rs
@@ -92,7 +92,7 @@ impl Socket {
         Self::bind_internal(addr, libc::AF_UNIX.into(), socket_type.into())
     }
 
-    pub(crate) fn from_std(socket: std::net::UdpSocket) -> Socket {
+    pub(crate) fn from_std<T: IntoRawFd>(socket: T) -> Socket {
         let fd = SharedFd::new(socket.into_raw_fd());
         Self::from_shared_fd(fd)
     }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -50,6 +50,21 @@ impl TcpStream {
         Ok(tcp_stream)
     }
 
+    /// Creates new `TcpStream` from a previously bound `std::net::TcpStream`.
+    ///
+    /// This function is intended to be used to wrap a TCP stream from the
+    /// standard library in the tokio-uring equivalent. The conversion assumes nothing
+    /// about the underlying socket; it is left up to the user to decide what socket
+    /// options are appropriate for their use case.
+    ///
+    /// This can be used in conjunction with socket2's `Socket` interface to
+    /// configure a socket before it's handed off, such as setting options like
+    /// `reuse_address` or binding to multiple addresses.
+    pub fn from_std(socket: std::net::TcpStream) -> Self {
+        let inner = Socket::from_std(socket);
+        Self { inner }
+    }
+
     pub(crate) fn from_socket(inner: Socket) -> Self {
         Self { inner }
     }
@@ -154,7 +169,6 @@ impl TcpStream {
     /// This function will cause all pending and future I/O on the specified portions to return
     /// immediately with an appropriate value.
     pub fn shutdown(&self, how: std::net::Shutdown) -> io::Result<()> {
-        // TODO same method for unix stream for consistency.
         self.inner.shutdown(how)
     }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,9 +1,13 @@
 use crate::{
     buf::{IoBuf, IoBufMut},
-    driver::Socket,
+    driver::{SharedFd, Socket},
 };
 use socket2::SockAddr;
-use std::{io, net::SocketAddr};
+use std::{
+    io,
+    net::SocketAddr,
+    os::unix::prelude::{AsRawFd, FromRawFd, RawFd},
+};
 
 /// A UDP socket.
 ///
@@ -95,7 +99,7 @@ impl UdpSocket {
     /// Creates new `UdpSocket` from a previously bound `std::net::UdpSocket`.
     ///
     /// This function is intended to be used to wrap a UDP socket from the
-    /// standard library in the Tokio equivalent. The conversion assumes nothing
+    /// standard library in the tokio-uring equivalent. The conversion assumes nothing
     /// about the underlying socket; it is left up to the user to decide what socket
     /// options are appropriate for their use case.
     ///
@@ -141,11 +145,13 @@ impl UdpSocket {
     ///     })
     /// }
     /// ```
-    pub fn from_std(socket: std::net::UdpSocket) -> UdpSocket {
-        let inner_socket = Socket::from_std(socket);
-        Self {
-            inner: inner_socket,
-        }
+    pub fn from_std(socket: std::net::UdpSocket) -> Self {
+        let inner = Socket::from_std(socket);
+        Self { inner }
+    }
+
+    pub(crate) fn from_socket(inner: Socket) -> Self {
+        Self { inner }
     }
 
     /// Connects this UDP socket to a remote address, allowing the `write` and
@@ -185,5 +191,25 @@ impl UdpSocket {
     /// quantity of data written.
     pub async fn write<T: IoBuf>(&self, buf: T) -> crate::BufResult<usize, T> {
         self.inner.write(buf).await
+    }
+
+    /// Shuts down the read, write, or both halves of this connection.
+    ///
+    /// This function will cause all pending and future I/O on the specified portions to return
+    /// immediately with an appropriate value.
+    pub fn shutdown(&self, how: std::net::Shutdown) -> io::Result<()> {
+        self.inner.shutdown(how)
+    }
+}
+
+impl FromRawFd for UdpSocket {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        UdpSocket::from_socket(Socket::from_shared_fd(SharedFd::new(fd)))
+    }
+}
+
+impl AsRawFd for UdpSocket {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.as_raw_fd()
     }
 }


### PR DESCRIPTION
A few features have been added to one or the other. This brings them back to parity with each other.

Socket:

    pub(crate) fn from_std<T: IntoRawFd>(socket: T) -> Socket

        Socket.from_std is changed from being UdpSocket specific to
        being generic over the IntoRawFd trait.

TcpStream:

    pub from_std(std::net::TcpStream) -> TcpStream

UdpSocket:

    pub(crate) fn from_socket(Socket) -> UdpSocket

    pub fn shutdown(std::net::Shutdown) -> io::Result<()>

    unsafe fn from_raw_fd(RawFd) -> UdpSocket

    fn as_raw_fd() -> RawFd

UnixStream:

    pub fn from_std(std::os::unix::net::UnixStream) -> UnixStream

    pub(crate) from_socket(Socket) -> UnixStream

    pub fn write_all<T: IoBuf>(mut buf: T) -> BufResult<(), T>

    pub fn shutdown(std::net::Shutdown) -> io::Result<()>

    unsafe fn from_raw_fd(RawFd) -> UdpSocket

    fn as_raw_fd() -> RawFd