### PR TITLE
Add benchmarks for no-op submission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,14 @@ jobs:
     steps:
       - run: exit 0
 
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update stable
+      - run: cargo bench --no-run
+
   check:
     runs-on: ubuntu-latest
     steps:
@@ -58,7 +66,6 @@ jobs:
       - name: Install Rust
         run: rustup update stable
       - run: cargo test --doc
-
 
   fmt:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,21 @@ socket2 = { version = "0.4.4", features = [ "all"] }
 bytes = { version = "1.0", optional = true }
 
 [dev-dependencies]
-bencher = "0.1.5"
 tempfile = "3.2.0"
-tokio = { version = "1.2", features = ["macros", "io-util"] }
 tokio-test = "0.4.2"
+iai = "0.1.1"
+futures = "0.3.25"
+criterion = "0.4.0"
 
 [package.metadata.docs.rs]
 all-features = true
+
+[[bench]]
+name = "lai_no_op"
+path = "benches/lai/no_op.rs"
+harness = false
+
+[[bench]]
+name = "criterion_no_op"
+path = "benches/criterion/no_op.rs"
+harness = false

--- a/benches/criterion/no_op.rs
+++ b/benches/criterion/no_op.rs
@@ -1,0 +1,79 @@
+use criterion::{
+    criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput,
+};
+use std::time::{Duration, Instant};
+
+use futures::stream::{self, StreamExt};
+
+#[derive(Clone)]
+struct Options {
+    iterations: usize,
+    concurrency: usize,
+    sq_size: usize,
+    cq_size: usize,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            iterations: 100000,
+            concurrency: 1,
+            sq_size: 128,
+            cq_size: 256,
+        }
+    }
+}
+
+fn run_no_ops(opts: &Options, count: u64) -> Duration {
+    let mut ring_opts = tokio_uring::uring_builder();
+    ring_opts
+        .setup_cqsize(opts.cq_size as _)
+        // .setup_sqpoll(10)
+        // .setup_sqpoll_cpu(1)
+        ;
+
+    let mut m = Duration::ZERO;
+
+    // Run the required number of iterations
+    for _ in 0..count {
+        m += tokio_uring::builder()
+            .entries(opts.sq_size as _)
+            .uring_builder(&ring_opts)
+            .start(async move {
+                let start = Instant::now();
+                stream::iter(0..opts.iterations)
+                    .for_each_concurrent(Some(opts.concurrency), |_| async move {
+                        tokio_uring::no_op().await.unwrap();
+                    })
+                    .await;
+                start.elapsed()
+            })
+    }
+    m
+}
+
+fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("no_op");
+    let mut opts = Options::default();
+    for concurrency in [1, 32, 64, 256].iter() {
+        opts.concurrency = *concurrency;
+
+        // We perform long running benchmarks: this is the best mode
+        group.sampling_mode(SamplingMode::Flat);
+
+        group.throughput(Throughput::Elements(opts.iterations as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(concurrency),
+            &opts,
+            |b, opts| {
+                // Custom iterator used because we don't expose access to runtime,
+                // which is required to do async benchmarking with criterion
+                b.iter_custom(move |iter| run_no_ops(opts, iter));
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/benches/lai/no_op.rs
+++ b/benches/lai/no_op.rs
@@ -1,0 +1,83 @@
+use futures::stream::{self, StreamExt};
+use iai::black_box;
+
+#[derive(Clone)]
+struct Options {
+    iterations: usize,
+    concurrency: usize,
+    sq_size: usize,
+    cq_size: usize,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            iterations: 100000,
+            concurrency: 1,
+            sq_size: 64,
+            cq_size: 256,
+        }
+    }
+}
+
+fn runtime_only() -> Result<(), Box<dyn std::error::Error>> {
+    let opts = Options::default();
+    let mut ring_opts = tokio_uring::uring_builder();
+    ring_opts
+        .setup_cqsize(opts.cq_size as _)
+        // .setup_sqpoll(10)
+        // .setup_sqpoll_cpu(1)
+        ;
+
+    tokio_uring::builder()
+        .entries(opts.sq_size as _)
+        .uring_builder(&ring_opts)
+        .start(async move { black_box(Ok(())) })
+}
+
+fn run_no_ops(opts: Options) -> Result<(), Box<dyn std::error::Error>> {
+    let mut ring_opts = tokio_uring::uring_builder();
+    ring_opts
+        .setup_cqsize(opts.cq_size as _)
+        // .setup_sqpoll(10)
+        // .setup_sqpoll_cpu(1)
+        ;
+
+    tokio_uring::builder()
+        .entries(opts.sq_size as _)
+        .uring_builder(&ring_opts)
+        .start(async move {
+            stream::iter(0..opts.iterations)
+                .for_each_concurrent(Some(opts.concurrency), |_| async move {
+                    tokio_uring::no_op().await.unwrap();
+                })
+                .await;
+            Ok(())
+        })
+}
+
+// This provides a baseline for estimating op overhead on top of this
+fn no_op_x1() -> Result<(), Box<dyn std::error::Error>> {
+    let opts = Options::default();
+    run_no_ops(black_box(opts))
+}
+
+fn no_op_x32() -> Result<(), Box<dyn std::error::Error>> {
+    let mut opts = Options::default();
+    opts.concurrency = 32;
+    run_no_ops(black_box(opts))
+}
+
+fn no_op_x64() -> Result<(), Box<dyn std::error::Error>> {
+    let mut opts = Options::default();
+    opts.concurrency = 64;
+    run_no_ops(black_box(opts))
+}
+
+fn no_op_x256() -> Result<(), Box<dyn std::error::Error>> {
+    let mut opts = Options::default();
+    opts.concurrency = 256;
+    run_no_ops(black_box(opts))
+}
+
+iai::main!(runtime_only, no_op_x1, no_op_x32, no_op_x64, no_op_x256);


### PR DESCRIPTION
This PR adds some baseline benchmarks for  `NoOp` submission / completion. This allows users to very roughly estimate the maximum bound for the throughput achievable using `tokio-uring`.

2 Benchmarks are added: Criterion, measuring wall time, and Lai, measuring cpu cycles. To run lai benchmarks, cachegrind is required.

###Notes
I've no doubt these can be improved, and should someone more experienced in micro-benchmarking wish to point out the glaring inefficiencies, I'd be very happy.

There are 2 lines of commented out code. These trigger a panic, issue #145 

### Some results
Hardware: 6 core i7

#### Criterion
```console
o_op/1                  time:   [145.16 ms 145.48 ms 145.82 ms]
                        thrpt:  [685.78 Kelem/s 687.38 Kelem/s 688.92 Kelem/s]
                 change:
                        time:   [-2.8876% -2.4510% -2.0114%] (p = 0.00 < 0.05)
                        thrpt:  [+2.0526% +2.5126% +2.9734%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
  
no_op/32                time:   [27.023 ms 27.078 ms 27.148 ms]
                        thrpt:  [3.6835 Melem/s 3.6930 Melem/s 3.7005 Melem/s]
                 change:
                        time:   [-1.3035% -0.9492% -0.5849%] (p = 0.00 < 0.05)
                        thrpt:  [+0.5883% +0.9583% +1.3207%]
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
  
no_op/64                time:   [25.175 ms 25.221 ms 25.274 ms]
                        thrpt:  [3.9567 Melem/s 3.9650 Melem/s 3.9722 Melem/s]
                 change:
                        time:   [-0.4796% -0.0752% +0.3019%] (p = 0.72 > 0.05)
                        thrpt:  [-0.3010% +0.0753% +0.4819%]
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
  
no_op/256               time:   [23.487 ms 23.539 ms 23.601 ms]
                        thrpt:  [4.2372 Melem/s 4.2482 Melem/s 4.2576 Melem/s]
                 change:
                        time:   [-2.9132% -2.5070% -2.0627%] (p = 0.00 < 0.05)
                        thrpt:  [+2.1062% +2.5715% +3.0006%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
```

#### Lai
```console
runtime_only
  Instructions:               28479 (No change)
  L1 Accesses:                40528 (No change)
  L2 Accesses:                  243 (No change)
  RAM Accesses:                 977 (No change)
  Estimated Cycles:           75938 (No change)

no_op_x1
  Instructions:           500699958 (+0.023513%)
  L1 Accesses:            754985269 (+0.015636%)
  L2 Accesses:              1575761 (No change)
  RAM Accesses:                1308 (No change)
  Estimated Cycles:       762909854 (+0.015474%)

no_op_x32
  Instructions:           129944394 (-0.008193%)
  L1 Accesses:            204870254 (-0.005207%)
  L2 Accesses:                49632 (No change)
  RAM Accesses:                1373 (No change)
  Estimated Cycles:       205166469 (-0.005200%)

no_op_x64
  Instructions:           123956020 (+0.003089%)
  L1 Accesses:            195968649 (+0.001997%)
  L2 Accesses:                39143 (No change)
  RAM Accesses:                1441 (No change)
  Estimated Cycles:       196214799 (+0.001994%)

no_op_x256
  Instructions:           119631265 (+0.000911%)
  L1 Accesses:            188921752 (+0.000577%)
  L2 Accesses:               649009 (No change)
  RAM Accesses:                1869 (No change)
  Estimated Cycles:       192232212 (+0.000567%)
```

