### PR TITLE
Expose runtime structure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ pub mod fs;
 pub mod net;
 
 pub use runtime::spawn;
+pub use runtime::Runtime;
 
 use std::future::Future;
 
@@ -140,7 +141,7 @@ use std::future::Future;
 /// }
 /// ```
 pub fn start<F: Future>(future: F) -> F::Output {
-    let mut rt = runtime::Runtime::new(&builder()).unwrap();
+    let rt = runtime::Runtime::new(&builder()).unwrap();
     rt.block_on(future)
 }
 
@@ -225,7 +226,7 @@ impl Builder {
     /// }
     /// ```
     pub fn start<F: Future>(&self, future: F) -> F::Output {
-        let mut rt = runtime::Runtime::new(self).unwrap();
+        let rt = runtime::Runtime::new(self).unwrap();
         rt.block_on(future)
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -6,7 +6,8 @@ use std::io;
 use tokio::io::unix::AsyncFd;
 use tokio::task::LocalSet;
 
-pub(crate) struct Runtime {
+/// The Runtime executor
+pub struct Runtime {
     /// io-uring driver
     driver: AsyncFd<Driver>,
 
@@ -48,7 +49,8 @@ pub fn spawn<T: std::future::Future + 'static>(task: T) -> tokio::task::JoinHand
 }
 
 impl Runtime {
-    pub(crate) fn new(b: &crate::Builder) -> io::Result<Runtime> {
+    /// Create a new tokio_uring runtime on the current thread
+    pub fn new(b: &crate::Builder) -> io::Result<Runtime> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .on_thread_park(|| {
                 CURRENT.with(|x| {
@@ -68,7 +70,8 @@ impl Runtime {
         Ok(Runtime { driver, local, rt })
     }
 
-    pub(crate) fn block_on<F>(&mut self, future: F) -> F::Output
+    /// Runs a future to completion on the current runtime
+    pub fn block_on<F>(&self, future: F) -> F::Output
     where
         F: Future,
     {


### PR DESCRIPTION
A recreation of #88, which doesn't seem to be updated. See discussion in that PR. Closes #91.

The motivationis as expressed in #91 and #88, to allow access to the runtime. An example of where this is used is criterion. If this is merged and a release issued, I will put a PR in to criterion with `AsyncExecutor` trait impl as a criterion feature. Until then, the following works

```rust
struct AsyncRuntime(tokio_uring::Runtime);

impl criterion::async_executor::AsyncExecutor for &AsyncRuntime {
    fn block_on<T>(&self, future: impl futures::Future<Output = T>) -> T {
        self.0.block_on(future)
    }
}

// ...

fn bench(c: &mut Criterion) {
    // ...
    let mut ring_opts = tokio_uring::uring_builder();  
    let mut builder = tokio_uring::builder();
    builder.uring_builder(&ring_opts);
    let runtime = AsyncRuntime(tokio_uring::Runtime::new(&builder).unwrap());
    let runtime = &runtime;

   c.bench_with_input(BenchmarkId::new("input_example", size), &size, |b, &s| {
        // Insert a call to `to_async` to convert the bencher to async mode.
        // The timing loops are the same as with the normal bencher.
        b.to_async(runtime).iter(|| do_something(s));
    });
}
```