### PR TITLE
chore: rename fields

### DIFF
--- a/src/driver/accept.rs
+++ b/src/driver/accept.rs
@@ -1,4 +1,4 @@
-use crate::driver::op::Completable;
+use crate::driver::op::{self, Completable};
 use crate::driver::{Op, SharedFd, Socket};
 use std::net::SocketAddr;
 use std::{boxed::Box, io};
@@ -37,8 +37,8 @@ impl Op<Accept> {
 impl Completable for Accept {
     type Output = io::Result<(Socket, Option<SocketAddr>)>;
 
-    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
-        let fd = result?;
+    fn complete(self, cqe: op::CqeResult) -> Self::Output {
+        let fd = cqe.result?;
         let fd = SharedFd::new(fd as i32);
         let socket = Socket { fd };
         let (_, addr) = unsafe {

--- a/src/driver/close.rs
+++ b/src/driver/close.rs
@@ -1,6 +1,6 @@
 use crate::driver::Op;
 
-use crate::driver::op::Completable;
+use crate::driver::op::{self, Completable};
 use std::io;
 use std::os::unix::io::RawFd;
 
@@ -21,8 +21,8 @@ impl Op<Close> {
 impl Completable for Close {
     type Output = io::Result<()>;
 
-    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
-        let _ = result?;
+    fn complete(self, cqe: op::CqeResult) -> Self::Output {
+        let _ = cqe.result?;
 
         Ok(())
     }

--- a/src/driver/connect.rs
+++ b/src/driver/connect.rs
@@ -1,4 +1,4 @@
-use crate::driver::op::Completable;
+use crate::driver::op::{self, Completable};
 use crate::driver::{Op, SharedFd};
 use socket2::SockAddr;
 use std::io;
@@ -36,7 +36,7 @@ impl Op<Connect> {
 impl Completable for Connect {
     type Output = io::Result<()>;
 
-    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
-        result.map(|_| ())
+    fn complete(self, cqe: op::CqeResult) -> Self::Output {
+        cqe.result.map(|_| ())
     }
 }

--- a/src/driver/fsync.rs
+++ b/src/driver/fsync.rs
@@ -2,7 +2,7 @@ use crate::driver::{Op, SharedFd};
 
 use std::io;
 
-use crate::driver::op::Completable;
+use crate::driver::op::{self, Completable};
 use io_uring::{opcode, types};
 
 pub(crate) struct Fsync {
@@ -28,7 +28,7 @@ impl Op<Fsync> {
 impl Completable for Fsync {
     type Output = io::Result<()>;
 
-    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
-        result.map(|_| ())
+    fn complete(self, cqe: op::CqeResult) -> Self::Output {
+        cqe.result.map(|_| ())
     }
 }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -39,7 +39,7 @@ mod write;
 
 mod writev;
 
-use io_uring::{cqueue, IoUring};
+use io_uring::IoUring;
 use scoped_tls::scoped_thread_local;
 use slab::Slab;
 use std::cell::RefCell;
@@ -61,9 +61,11 @@ pub(crate) struct Inner {
     pub(crate) uring: IoUring,
 }
 
-// When dropping the driver, all in-flight operations must have completed. This
-// type wraps the slab and ensures that, on drop, the slab is empty.
-struct Ops(Slab<op::Lifecycle>);
+struct Ops {
+    // When dropping the driver, all in-flight operations must have completed. This
+    // type wraps the slab and ensures that, on drop, the slab is empty.
+    lifecycle: Slab<op::Lifecycle>,
+}
 
 scoped_thread_local!(pub(crate) static CURRENT: Rc<RefCell<Inner>>);
 
@@ -98,7 +100,7 @@ impl Driver {
 
     fn num_operations(&self) -> usize {
         let inner = self.inner.borrow();
-        inner.ops.0.len()
+        inner.ops.lifecycle.len()
     }
 }
 
@@ -117,7 +119,7 @@ impl Inner {
 
             let index = cqe.user_data() as _;
 
-            self.ops.complete(index, resultify(&cqe), cqe.flags());
+            self.ops.complete(index, cqe.into());
         }
     }
 
@@ -158,42 +160,34 @@ impl Drop for Driver {
 
 impl Ops {
     fn new() -> Ops {
-        Ops(Slab::with_capacity(64))
+        Ops {
+            lifecycle: Slab::with_capacity(64),
+        }
     }
 
     fn get_mut(&mut self, index: usize) -> Option<&mut op::Lifecycle> {
-        self.0.get_mut(index)
+        self.lifecycle.get_mut(index)
     }
 
     // Insert a new operation
     fn insert(&mut self) -> usize {
-        self.0.insert(op::Lifecycle::Submitted)
+        self.lifecycle.insert(op::Lifecycle::Submitted)
     }
 
     // Remove an operation
     fn remove(&mut self, index: usize) {
-        self.0.remove(index);
+        self.lifecycle.remove(index);
     }
 
-    fn complete(&mut self, index: usize, result: io::Result<u32>, flags: u32) {
-        if self.0[index].complete(result, flags) {
-            self.0.remove(index);
+    fn complete(&mut self, index: usize, cqe: op::CqeResult) {
+        if self.lifecycle[index].complete(cqe) {
+            self.lifecycle.remove(index);
         }
     }
 }
 
 impl Drop for Ops {
     fn drop(&mut self) {
-        assert!(self.0.is_empty());
-    }
-}
-
-fn resultify(cqe: &cqueue::Entry) -> io::Result<u32> {
-    let res = cqe.result();
-
-    if res >= 0 {
-        Ok(res as u32)
-    } else {
-        Err(io::Error::from_raw_os_error(-res))
+        assert!(self.lifecycle.is_empty());
     }
 }

--- a/src/driver/noop.rs
+++ b/src/driver/noop.rs
@@ -1,4 +1,7 @@
-use crate::driver::{op::Completable, Op};
+use crate::driver::{
+    op::{self, Completable},
+    Op,
+};
 use std::io;
 
 /// No operation. Just posts a completion event, nothing else.
@@ -17,8 +20,8 @@ impl Op<NoOp> {
 impl Completable for NoOp {
     type Output = io::Result<()>;
 
-    fn complete(self, _result: io::Result<u32>, _flags: u32) -> Self::Output {
-        Ok(())
+    fn complete(self, cqe: op::CqeResult) -> Self::Output {
+        cqe.result.map(|_| ())
     }
 }
 

--- a/src/driver/open.rs
+++ b/src/driver/open.rs
@@ -1,7 +1,7 @@
 use crate::driver::{self, Op, SharedFd};
 use crate::fs::{File, OpenOptions};
 
-use crate::driver::op::Completable;
+use crate::driver::op::{self, Completable};
 use std::ffi::CString;
 use std::io;
 use std::path::Path;
@@ -40,7 +40,7 @@ impl Op<Open> {
 impl Completable for Open {
     type Output = io::Result<File>;
 
-    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
-        Ok(File::from_shared_fd(SharedFd::new(result? as _)))
+    fn complete(self, cqe: op::CqeResult) -> Self::Output {
+        Ok(File::from_shared_fd(SharedFd::new(cqe.result? as _)))
     }
 }

--- a/src/driver/read.rs
+++ b/src/driver/read.rs
@@ -2,7 +2,7 @@ use crate::buf::IoBufMut;
 use crate::driver::{Op, SharedFd};
 use crate::BufResult;
 
-use crate::driver::op::Completable;
+use crate::driver::op::{self, Completable};
 use std::io;
 
 pub(crate) struct Read<T> {
@@ -42,9 +42,9 @@ where
 {
     type Output = BufResult<usize, T>;
 
-    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
+    fn complete(self, cqe: op::CqeResult) -> Self::Output {
         // Convert the operation result to `usize`
-        let res = result.map(|v| v as usize);
+        let res = cqe.result.map(|v| v as usize);
         // Recover the buffer
         let mut buf = self.buf;
 

--- a/src/driver/readv.rs
+++ b/src/driver/readv.rs
@@ -2,7 +2,7 @@ use crate::buf::IoBufMut;
 use crate::driver::{Op, SharedFd};
 use crate::BufResult;
 
-use crate::driver::op::Completable;
+use crate::driver::op::{self, Completable};
 use libc::iovec;
 use std::io;
 
@@ -61,9 +61,9 @@ where
 {
     type Output = BufResult<usize, Vec<T>>;
 
-    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
+    fn complete(self, cqe: op::CqeResult) -> Self::Output {
         // Convert the operation result to `usize`
-        let res = result.map(|v| v as usize);
+        let res = cqe.result.map(|v| v as usize);
         // Recover the buffer
         let mut bufs = self.bufs;
 

--- a/src/driver/recv_from.rs
+++ b/src/driver/recv_from.rs
@@ -1,4 +1,4 @@
-use crate::driver::op::Completable;
+use crate::driver::op::{self, Completable};
 use crate::{
     buf::IoBufMut,
     driver::{Op, SharedFd},
@@ -60,9 +60,9 @@ where
 {
     type Output = BufResult<(usize, SocketAddr), T>;
 
-    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
+    fn complete(self, cqe: op::CqeResult) -> Self::Output {
         // Convert the operation result to `usize`
-        let res = result.map(|v| v as usize);
+        let res = cqe.result.map(|v| v as usize);
         // Recover the buffer
         let mut buf = self.buf;
 

--- a/src/driver/rename_at.rs
+++ b/src/driver/rename_at.rs
@@ -1,6 +1,6 @@
 use crate::driver::{self, Op};
 
-use crate::driver::op::Completable;
+use crate::driver::op::{self, Completable};
 use std::ffi::CString;
 use std::io;
 use std::path::Path;
@@ -44,7 +44,7 @@ impl Op<RenameAt> {
 impl Completable for RenameAt {
     type Output = io::Result<()>;
 
-    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
-        result.map(|_| ())
+    fn complete(self, cqe: op::CqeResult) -> Self::Output {
+        cqe.result.map(|_| ())
     }
 }

--- a/src/driver/send_to.rs
+++ b/src/driver/send_to.rs
@@ -1,5 +1,5 @@
 use crate::buf::IoBuf;
-use crate::driver::op::Completable;
+use crate::driver::op::{self, Completable};
 use crate::driver::{Op, SharedFd};
 use crate::BufResult;
 use socket2::SockAddr;
@@ -62,9 +62,9 @@ where
 {
     type Output = BufResult<usize, T>;
 
-    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
+    fn complete(self, cqe: op::CqeResult) -> Self::Output {
         // Convert the operation result to `usize`
-        let res = result.map(|v| v as usize);
+        let res = cqe.result.map(|v| v as usize);
         // Recover the buffer
         let buf = self.buf;
 

--- a/src/driver/unlink_at.rs
+++ b/src/driver/unlink_at.rs
@@ -1,6 +1,6 @@
 use crate::driver::{self, Op};
 
-use crate::driver::op::Completable;
+use crate::driver::op::{self, Completable};
 use std::ffi::CString;
 use std::io;
 use std::path::Path;
@@ -42,7 +42,7 @@ impl Op<Unlink> {
 impl Completable for Unlink {
     type Output = io::Result<()>;
 
-    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
-        result.map(|_| ())
+    fn complete(self, cqe: op::CqeResult) -> Self::Output {
+        cqe.result.map(|_| ())
     }
 }

--- a/src/driver/write.rs
+++ b/src/driver/write.rs
@@ -1,4 +1,4 @@
-use crate::driver::op::Completable;
+use crate::driver::op::{self, Completable};
 use crate::{
     buf::IoBuf,
     driver::{Op, SharedFd},
@@ -43,9 +43,9 @@ where
 {
     type Output = BufResult<usize, T>;
 
-    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
+    fn complete(self, cqe: op::CqeResult) -> Self::Output {
         // Convert the operation result to `usize`
-        let res = result.map(|v| v as usize);
+        let res = cqe.result.map(|v| v as usize);
         // Recover the buffer
         let buf = self.buf;
 

--- a/src/driver/writev.rs
+++ b/src/driver/writev.rs
@@ -1,4 +1,4 @@
-use crate::driver::op::Completable;
+use crate::driver::op::{self, Completable};
 use crate::{
     buf::IoBuf,
     driver::{Op, SharedFd},
@@ -61,9 +61,9 @@ where
 {
     type Output = BufResult<usize, Vec<T>>;
 
-    fn complete(self, result: io::Result<u32>, _flags: u32) -> Self::Output {
+    fn complete(self, cqe: op::CqeResult) -> Self::Output {
         // Convert the operation result to `usize`
-        let res = result.map(|v| v as usize);
+        let res = cqe.result.map(|v| v as usize);
         // Recover the buffer
         let buf = self.bufs;
 


### PR DESCRIPTION
Initially requested by @Noah-Kennedy as part of #130, and requested as a separate PR by @FrankReh, this Pr

- Convert cqe type from tuple to struct CqeResult
- Adds a named field to Ops, rather than an anonymous tuple-1