### PR TITLE
chore: reduce noise in benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,16 @@ bytes = { version = "1.0", optional = true }
 tempfile = "3.2.0"
 tokio-test = "0.4.2"
 iai = "0.1.1"
-futures = "0.3.25"
 criterion = "0.4.0"
 # we use joinset in our tests
-tokio = "1.21.0"
+tokio = "1.21.2"
 nix = "0.26.1"
 
 [package.metadata.docs.rs]
 all-features = true
+
+[profile.bench]
+debug = true
 
 [[bench]]
 name = "lai_no_op"

--- a/benches/criterion/no_op.rs
+++ b/benches/criterion/no_op.rs
@@ -26,11 +26,7 @@ impl Default for Options {
 
 fn run_no_ops(opts: &Options, count: u64) -> Duration {
     let mut ring_opts = tokio_uring::uring_builder();
-    ring_opts
-        .setup_cqsize(opts.cq_size as _)
-        // .setup_sqpoll(10)
-        // .setup_sqpoll_cpu(1)
-        ;
+    ring_opts.setup_cqsize(opts.cq_size as _);
 
     let mut m = Duration::ZERO;
 

--- a/benches/lai/no_op.rs
+++ b/benches/lai/no_op.rs
@@ -23,11 +23,7 @@ impl Default for Options {
 fn runtime_only() -> Result<(), Box<dyn std::error::Error>> {
     let opts = Options::default();
     let mut ring_opts = tokio_uring::uring_builder();
-    ring_opts
-        .setup_cqsize(opts.cq_size as _)
-        // .setup_sqpoll(10)
-        // .setup_sqpoll_cpu(1)
-        ;
+    ring_opts.setup_cqsize(opts.cq_size as _);
 
     tokio_uring::builder()
         .entries(opts.sq_size as _)
@@ -37,11 +33,7 @@ fn runtime_only() -> Result<(), Box<dyn std::error::Error>> {
 
 fn run_no_ops(opts: Options) -> Result<(), Box<dyn std::error::Error>> {
     let mut ring_opts = tokio_uring::uring_builder();
-    ring_opts
-        .setup_cqsize(opts.cq_size as _)
-        // .setup_sqpoll(10)
-        // .setup_sqpoll_cpu(1)
-        ;
+    ring_opts.setup_cqsize(opts.cq_size as _);
 
     tokio_uring::builder()
         .entries(opts.sq_size as _)

--- a/benches/lai/no_op.rs
+++ b/benches/lai/no_op.rs
@@ -1,5 +1,5 @@
-use futures::stream::{self, StreamExt};
 use iai::black_box;
+use tokio::task::JoinSet;
 
 #[derive(Clone)]
 struct Options {
@@ -47,11 +47,16 @@ fn run_no_ops(opts: Options) -> Result<(), Box<dyn std::error::Error>> {
         .entries(opts.sq_size as _)
         .uring_builder(&ring_opts)
         .start(async move {
-            stream::iter(0..opts.iterations)
-                .for_each_concurrent(Some(opts.concurrency), |_| async move {
-                    tokio_uring::no_op().await.unwrap();
-                })
-                .await;
+            let mut js = JoinSet::new();
+
+            for _ in 0..opts.iterations {
+                js.spawn_local(tokio_uring::no_op());
+            }
+
+            while let Some(res) = js.join_next().await {
+                res.unwrap().unwrap();
+            }
+
             Ok(())
         })
 }


### PR DESCRIPTION
Removes FuturesUnordered from benchmarks and alters timing to ignore task spawning, as to hone in on specifically the processing of ops and driver performance.