### PR TITLE
driver: improve cqueue dispatch

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -77,20 +77,30 @@ impl Driver {
     }
 
     pub(crate) fn tick(&mut self) {
-        let mut cq = self.uring.completion();
-        cq.sync();
+        loop {
+            let mut cq = self.uring.completion();
 
-        for cqe in cq {
-            if cqe.user_data() == u64::MAX {
-                // Result of the cancellation action. There isn't anything we
-                // need to do here. We must wait for the CQE for the operation
-                // that was canceled.
-                continue;
+            cq.sync();
+
+            // if the cqueue is full, we are experiencing overflow and need to keep looping
+            let should_continue = cq.is_full();
+
+            for cqe in cq {
+                if cqe.user_data() == u64::MAX {
+                    // Result of the cancellation action. There isn't anything we
+                    // need to do here. We must wait for the CQE for the operation
+                    // that was canceled.
+                    continue;
+                }
+
+                let index = cqe.user_data() as _;
+
+                self.ops.complete(index, cqe.into());
             }
 
-            let index = cqe.user_data() as _;
-
-            self.ops.complete(index, cqe.into());
+            if !should_continue {
+                break;
+            }
         }
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -62,7 +62,22 @@ impl Runtime {
         let rt = tokio::runtime::Builder::new_current_thread()
             .on_thread_park(|| {
                 CONTEXT.with(|x| {
-                    let _ = x.with_driver_mut(|d| d.uring.submit());
+                    let _ = x.with_driver_mut(|d| {
+                        // optimization: we can potentially avoid an epoll_wait call if we try to
+                        // dispatch completions before we park on epoll
+                        d.tick();
+                        d.submit()
+                    });
+                });
+            })
+            .on_thread_unpark(|| {
+                CONTEXT.with(|x| {
+                    let _ = x.with_driver_mut(|d| {
+                        // Dispatch completions to wake tasks based on any completed ops.
+                        // this is an optimization to try and avoid the whole "give the io driver
+                        // a dedicated task" thing
+                        d.tick();
+                    });
                 });
             })
             .enable_all()
@@ -106,11 +121,10 @@ impl Runtime {
 
         self.local.spawn_local(drive);
 
-        self.rt
-            .block_on(self.local.run_until(crate::future::poll_fn(|cx| {
-                // assert!(drive.as_mut().poll(cx).is_pending());
-                future.as_mut().poll(cx)
-            })))
+        self.rt.block_on(
+            self.local
+                .run_until(crate::future::poll_fn(|cx| future.as_mut().poll(cx))),
+        )
     }
 }
 


### PR DESCRIPTION
This PR makes a few changes:
- It changes our ticking behavior to loop on a full cqueue to ensure that we actually fully clear out the queue in the event of an overflow.
- It adds an optimization to our parking routine which allows us to potentially wake tasks instead of parking on epoll.
- It makes our parking routines attempt to tick futures if we hit EBUSY