### PR TITLE
Depend on io-uring version ^0.5.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ tokio = { version = "1.2", features = ["net", "rt"] }
 scoped-tls = "1.0.0"
 slab = "0.4.2"
 libc = "0.2.80"
-io-uring = { version = "0.5.0", features = [ "unstable" ] }
-socket2 = { version = "0.4.4", features = [ "all"] }
+io-uring = { version = "0.5.8", features = ["unstable"] }
+socket2 = { version = "0.4.4", features = ["all"] }
 bytes = { version = "1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
io-uring v0.5.8 handles the overflow of the cqueue so this bump on the dependancy fixes hangs caused when high frequency submissions fill the cqueue.

While we're at it, adds a unit test for such a hanging cqueue.