### PR TITLE
Ignore errors from uring while cleaning up

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -126,7 +126,7 @@ impl Drop for Driver {
         while self.num_operations() > 0 {
             // If waiting fails, ignore the error. The wait will be attempted
             // again on the next loop.
-            let _ = self.wait().unwrap();
+            _ = self.wait();
             self.tick();
         }
     }


### PR DESCRIPTION
In the driver drop code, don't assume the call to wait for a completion will always succeed. This assumption can lead to a panic as we were unwrapping an error result.