### PR TITLE
rt: drop runtime before driver during shutdown

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -126,7 +126,7 @@ impl Drop for Driver {
         while self.num_operations() > 0 {
             // If waiting fails, ignore the error. The wait will be attempted
             // again on the next loop.
-            _ = self.wait();
+            let _ = self.wait();
             self.tick();
         }
     }


### PR DESCRIPTION
This fixes the issue where we can potentially drop the driver while there are active tasks on the runtime.