### PR TITLE
rt: refactor drop logic

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,6 +1,5 @@
 use crate::driver::Driver;
 
-use libc::servent;
 use std::future::Future;
 use std::io;
 use std::mem::ManuallyDrop;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,7 +1,9 @@
 use crate::driver::Driver;
 
+use libc::servent;
 use std::future::Future;
 use std::io;
+use std::mem::ManuallyDrop;
 use std::os::unix::io::{AsRawFd, RawFd};
 use tokio::io::unix::AsyncFd;
 use tokio::task::LocalSet;
@@ -20,19 +22,10 @@ pub struct Runtime {
     uring_fd: RawFd,
 
     /// LocalSet for !Send tasks
-    local: LocalSet,
+    local: ManuallyDrop<LocalSet>,
 
     /// Tokio runtime, always current-thread
-    rt: tokio::runtime::Runtime,
-
-    /// This is here for drop order reasons.
-    ///
-    /// We can't unset the driver in the runtime drop method, because the inner runtime needs to
-    /// be dropped first so that there are no tasks running.
-    ///
-    /// The rust drop order rules guarantee that the inner runtime will be dropped first, and
-    /// this last.
-    _driver_guard: RuntimeContextGuard,
+    rt: ManuallyDrop<tokio::runtime::Runtime>,
 }
 
 /// Spawns a new asynchronous task, returning a [`JoinHandle`] for it.
@@ -77,7 +70,9 @@ impl Runtime {
             .enable_all()
             .build()?;
 
-        let local = LocalSet::new();
+        let rt = ManuallyDrop::new(rt);
+
+        let local = ManuallyDrop::new(LocalSet::new());
 
         let driver = Driver::new(b)?;
 
@@ -89,7 +84,6 @@ impl Runtime {
             uring_fd: driver_fd,
             local,
             rt,
-            _driver_guard: RuntimeContextGuard,
         })
     }
 
@@ -124,10 +118,16 @@ impl Runtime {
     }
 }
 
-struct RuntimeContextGuard;
-
-impl Drop for RuntimeContextGuard {
+impl Drop for Runtime {
     fn drop(&mut self) {
+        // drop tasks
+        unsafe {
+            ManuallyDrop::drop(&mut self.local);
+            ManuallyDrop::drop(&mut self.rt);
+        }
+
+        // once tasks are dropped, we can unset the driver
+        // this will block until all completions are received
         CONTEXT.with(|rc| rc.unset_driver())
     }
 }


### PR DESCRIPTION
This shouldn't change any functionality, but it does use ManuallyDrop to cleanup the drop logic a fair bit. This is much nicer than relying on drop order.