### PR TITLE
rt: fix error when calling block_on twice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ tokio-test = "0.4.2"
 iai = "0.1.1"
 futures = "0.3.25"
 criterion = "0.4.0"
+# we use joinset in our tests
+tokio = "1.21.0"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This fixes an issue where we would try and spawn a separate background task on the `LocalSet` for watching the `AsyncFd` for the uring instance every time we called `block_on`. Now, we only spawn at runtime creation.