### PR TITLE
driver: MultiCqe support for Driver Drop

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -202,7 +202,7 @@ impl Drop for Driver {
             };
 
             // Remove completed lifecycles from Slab.
-            // This prevents worst case quadtratic processing
+            // This prevents worst case quadratic processing
             if let Some(id) = remove {
                 self.ops.lifecycle.remove(id);
             } else {

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -188,11 +188,11 @@ impl Drop for Driver {
             }
         }
 
-        // Wait until all Lifetimes have been removed from the slab. 
+        // Wait until all Lifetimes have been removed from the slab.
         //
         // Ignored entries will be removed from the Lifecycle slab
         // by the complete logic called by `tick()`
-        // 
+        //
         // Completed Entries are removed here directly
         let mut id = 0;
         loop {

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -202,7 +202,7 @@ impl Drop for Driver {
                 let _ = self.wait();
                 self.tick();
             } else {
-                id +=1;
+                id += 1;
             };
         }
     }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -196,14 +196,23 @@ impl Drop for Driver {
             }
             // Cycles are either all ignored or complete
             // If there is at least one Ignored still to process, call wait
-            if let Some(Lifecycle::Ignored(..)) = self.ops.lifecycle.get(id) {
-                // If waiting fails, ignore the error. The wait will be attempted
-                // again on the next loop.
-                let _ = self.wait();
-                self.tick();
-            } else {
-                id += 1;
-            };
+            match self.ops.lifecycle.get(id) {
+                Some(Lifecycle::Ignored(..)) => {
+                    // If waiting fails, ignore the error. The wait will be attempted
+                    // again on the next loop.
+                    let _ = self.wait();
+                    self.tick();
+                }
+
+                Some(_) => {
+                    let _ = self.ops.lifecycle.remove(id);
+                    id += 1;
+                }
+
+                None => {
+                    id += 1;
+                }
+            }
         }
     }
 }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -201,7 +201,7 @@ impl Drop for Driver {
                 None
             };
 
-            // Remove completed lifecycles from Slab.
+            // Remove completed lifecycles from Slab
             // This prevents worst case quadratic processing
             if let Some(id) = remove {
                 self.ops.lifecycle.remove(id);

--- a/src/driver/op/slab_list.rs
+++ b/src/driver/op/slab_list.rs
@@ -15,6 +15,7 @@ pub(crate) struct SlabList<'a, T> {
 }
 
 // Indices to the head and tail of a single list held within a SlabList
+#[derive(Clone)]
 pub(crate) struct SlabListIndices {
     start: usize,
     end: usize,


### PR DESCRIPTION
Handles `LifeCycle::CompletionList` in driver Drop logic

During the first pass over all lifecycles, identifies if CompletionLists are finished or not. 

  - If they are, it changes the Lifecycle to Completed with null data.
  - If they are not, adds them to the cancel list, and converts to Ignored

This means that after this pass, we will never observe `CompletionList` in the lifecycles. This means the existing termination logic is ok unchanged. The ignored entry will stay until removed from the Lifecycle slab by the call to complete.

Fixes a gap left by #158 and unblocks #123 