### PR TITLE
Add a Builder framework

### DIFF
--- a/src/driver/fsync.rs
+++ b/src/driver/fsync.rs
@@ -2,26 +2,46 @@ use crate::driver::{Op, SharedFd};
 
 use std::io;
 
-use crate::driver::op::{self, Completable};
+use crate::driver::op::{self, Buildable, Completable};
 use io_uring::{opcode, types};
 
 pub(crate) struct Fsync {
     fd: SharedFd,
+    flags: Option<types::FsyncFlags>,
 }
 
 impl Op<Fsync> {
     pub(crate) fn fsync(fd: &SharedFd) -> io::Result<Op<Fsync>> {
-        Op::submit_with(Fsync { fd: fd.clone() }, |fsync| {
-            opcode::Fsync::new(types::Fd(fsync.fd.raw_fd())).build()
-        })
+        Fsync {
+            fd: fd.clone(),
+            flags: None,
+        }
+        .submit()
     }
 
     pub(crate) fn datasync(fd: &SharedFd) -> io::Result<Op<Fsync>> {
-        Op::submit_with(Fsync { fd: fd.clone() }, |fsync| {
-            opcode::Fsync::new(types::Fd(fsync.fd.raw_fd()))
-                .flags(types::FsyncFlags::DATASYNC)
-                .build()
-        })
+        Fsync {
+            fd: fd.clone(),
+            flags: Some(types::FsyncFlags::DATASYNC),
+        }
+        .submit()
+    }
+}
+
+impl Buildable for Fsync
+where
+    Self: 'static + Sized,
+{
+    type CqeType = op::SingleCQE;
+
+    fn create_sqe(&mut self) -> io_uring::squeue::Entry {
+        let mut opcode = opcode::Fsync::new(types::Fd(self.fd.raw_fd()));
+
+        if let Some(flags) = self.flags {
+            opcode.flags(flags);
+        }
+
+        opcode.build()
     }
 }
 

--- a/src/driver/fsync.rs
+++ b/src/driver/fsync.rs
@@ -35,13 +35,13 @@ where
     type CqeType = op::SingleCQE;
 
     fn create_sqe(&mut self) -> io_uring::squeue::Entry {
-        let mut opcode = opcode::Fsync::new(types::Fd(self.fd.raw_fd()));
+        let opcode = opcode::Fsync::new(types::Fd(self.fd.raw_fd()));
 
         if let Some(flags) = self.flags {
-            opcode.flags(flags);
+            opcode.flags(flags).build()
+        } else {
+            opcode.build()
         }
-
-        opcode.build()
     }
 }
 

--- a/src/driver/noop.rs
+++ b/src/driver/noop.rs
@@ -1,5 +1,5 @@
 use crate::driver::{
-    op::{self, Completable},
+    op::{self, Buildable, Completable},
     Op,
 };
 use std::io;
@@ -11,9 +11,18 @@ pub struct NoOp {}
 
 impl Op<NoOp> {
     pub fn no_op() -> io::Result<Op<NoOp>> {
-        use io_uring::opcode;
+        NoOp {}.submit()
+    }
+}
 
-        Op::submit_with(NoOp {}, |_| opcode::Nop::new().build())
+impl Buildable for NoOp
+where
+    Self: 'static + Sized,
+{
+    type CqeType = op::SingleCQE;
+
+    fn create_sqe(&mut self) -> io_uring::squeue::Entry {
+        io_uring::opcode::Nop::new().build()
     }
 }
 

--- a/src/driver/rename_at.rs
+++ b/src/driver/rename_at.rs
@@ -1,6 +1,6 @@
 use crate::driver::{self, Op};
 
-use crate::driver::op::{self, Completable};
+use crate::driver::op::{self, Buildable, Completable};
 use std::ffi::CString;
 use std::io;
 use std::path::Path;
@@ -12,32 +12,42 @@ use std::path::Path;
 pub(crate) struct RenameAt {
     pub(crate) from: CString,
     pub(crate) to: CString,
+    flags: u32,
 }
 
 impl Op<RenameAt> {
     /// Submit a request to rename a specified path to a new name with
     /// the provided flags.
     pub(crate) fn rename_at(from: &Path, to: &Path, flags: u32) -> io::Result<Op<RenameAt>> {
-        use io_uring::{opcode, types};
-
         let from = driver::util::cstr(from)?;
         let to = driver::util::cstr(to)?;
 
-        Op::submit_with(RenameAt { from, to }, |rename| {
-            // Get a reference to the memory. The string will be held by the
-            // operation state and will not be accessed again until the operation
-            // completes.
-            let from_ref = rename.from.as_c_str().as_ptr();
-            let to_ref = rename.to.as_c_str().as_ptr();
-            opcode::RenameAt::new(
-                types::Fd(libc::AT_FDCWD),
-                from_ref,
-                types::Fd(libc::AT_FDCWD),
-                to_ref,
-            )
-            .flags(flags)
-            .build()
-        })
+        RenameAt { from, to, flags }.submit()
+    }
+}
+
+impl Buildable for RenameAt
+where
+    Self: 'static + Sized,
+{
+    type CqeType = op::SingleCQE;
+
+    fn create_sqe(&mut self) -> io_uring::squeue::Entry {
+        use io_uring::{opcode, types};
+
+        // Get a reference to the memory. The string will be held by the
+        // operation state and will not be accessed again until the operation
+        // completes.
+        let from_ref = self.from.as_c_str().as_ptr();
+        let to_ref = self.to.as_c_str().as_ptr();
+        opcode::RenameAt::new(
+            types::Fd(libc::AT_FDCWD),
+            from_ref,
+            types::Fd(libc::AT_FDCWD),
+            to_ref,
+        )
+        .flags(self.flags)
+        .build()
     }
 }
 

--- a/src/driver/send_to.rs
+++ b/src/driver/send_to.rs
@@ -1,5 +1,5 @@
 use crate::buf::IoBuf;
-use crate::driver::op::{self, Completable};
+use crate::driver::op::{self, Buildable, Completable};
 use crate::driver::{Op, SharedFd};
 use crate::BufResult;
 use socket2::SockAddr;
@@ -23,8 +23,6 @@ impl<T: IoBuf> Op<SendTo<T>> {
         buf: T,
         socket_addr: SocketAddr,
     ) -> io::Result<Op<SendTo<T>>> {
-        use io_uring::{opcode, types};
-
         let io_slices = vec![IoSlice::new(unsafe {
             std::slice::from_raw_parts(buf.stable_ptr(), buf.bytes_init())
         })];
@@ -37,22 +35,31 @@ impl<T: IoBuf> Op<SendTo<T>> {
         msghdr.msg_name = socket_addr.as_ptr() as *mut libc::c_void;
         msghdr.msg_namelen = socket_addr.len();
 
-        Op::submit_with(
-            SendTo {
-                fd: fd.clone(),
-                buf,
-                io_slices,
-                socket_addr,
-                msghdr,
-            },
-            |send_to| {
-                opcode::SendMsg::new(
-                    types::Fd(send_to.fd.raw_fd()),
-                    send_to.msghdr.as_ref() as *const _,
-                )
-                .build()
-            },
+        SendTo {
+            fd: fd.clone(),
+            buf,
+            io_slices,
+            socket_addr,
+            msghdr,
+        }
+        .submit()
+    }
+}
+
+impl<T: IoBuf> op::Buildable for SendTo<T>
+where
+    Self: 'static + Sized,
+{
+    type CqeType = op::SingleCQE;
+
+    fn create_sqe(&mut self) -> io_uring::squeue::Entry {
+        use io_uring::{opcode, types};
+
+        opcode::SendMsg::new(
+            types::Fd(self.fd.raw_fd()),
+            self.msghdr.as_ref() as *const _,
         )
+        .build()
     }
 }
 

--- a/src/driver/unlink_at.rs
+++ b/src/driver/unlink_at.rs
@@ -1,6 +1,6 @@
 use crate::driver::{self, Op};
 
-use crate::driver::op::{self, Completable};
+use crate::driver::op::{self, Buildable, Completable};
 use std::ffi::CString;
 use std::io;
 use std::path::Path;
@@ -8,6 +8,8 @@ use std::path::Path;
 /// Unlink a path relative to the current working directory of the caller's process.
 pub(crate) struct Unlink {
     pub(crate) path: CString,
+
+    flags: i32,
 }
 
 impl Op<Unlink> {
@@ -23,19 +25,28 @@ impl Op<Unlink> {
 
     /// Submit a request to unlink a specifed path with provided flags.
     pub(crate) fn unlink(path: &Path, flags: i32) -> io::Result<Op<Unlink>> {
-        use io_uring::{opcode, types};
-
         let path = driver::util::cstr(path)?;
 
-        Op::submit_with(Unlink { path }, |unlink| {
-            // Get a reference to the memory. The string will be held by the
-            // operation state and will not be accessed again until the operation
-            // completes.
-            let p_ref = unlink.path.as_c_str().as_ptr();
-            opcode::UnlinkAt::new(types::Fd(libc::AT_FDCWD), p_ref)
-                .flags(flags)
-                .build()
-        })
+        Unlink { path, flags }.submit()
+    }
+}
+
+impl op::Buildable for Unlink
+where
+    Self: 'static + Sized,
+{
+    type CqeType = op::SingleCQE;
+
+    fn create_sqe(&mut self) -> io_uring::squeue::Entry {
+        use io_uring::{opcode, types};
+
+        // Get a reference to the memory. The string will be held by the
+        // operation state and will not be accessed again until the operation
+        // completes.
+        let p_ref = self.path.as_c_str().as_ptr();
+        opcode::UnlinkAt::new(types::Fd(libc::AT_FDCWD), p_ref)
+            .flags(self.flags)
+            .build()
     }
 }
 


### PR DESCRIPTION
This PR Introduces 

```rust
pub(crate) trait Buildable
where
    Self: 'static + Sized + Completable,
{
    // The CqeType type which results from Submission
    type CqeType;

    // The closure from submit_with, made a function
    fn create_sqe(&mut self) -> squeue::Entry;

    /// Build an Operation, and submit to uring.
    ///
    /// `state` is stored during the operation tracking any state submitted to
    /// the kernel.
    fn submit(mut self) -> io::Result<Op<Self, <Self as Buildable>::CqeType>> {
        todo!("This was previously `submit_with` in impl Op")
    }
}
```

And provides an implementation for all Ops (there are a _lot_ aren't there?).  
Where an Op is `Op<OP_HERE,_>`. This makes a lot of sense, as the structs already contained all (or most) of the data required to create the Op itself.

What this PR doesn't do is expose them, it just puts the framework in place. Tests still pass, and Benchmarks improve fractionally, seemingly due to better L1 cache hits. Haven't looked into, and not that interested in why.

Future PR's can go several ways from here. 
  - Ops can have Builder APi's wrapped around them one at a time, and things will just work
  - Ops can be linked. If we view a link as consuming a builder, which I think is correct, because you must ensure its not yet been submitted, which the builder does. I don't plan on doing linking in this PR, although might show it bolted on top.  I left some commented code to show where it would go, which provides it to all ops.
  
For the sake of clarity, this doesn't introduce Deferred Ops, which is a seperate concern. It doesn't block it either.

d as draft because I expect significant discussion


