### PR TITLE
bug: send_zc should be a MultiCQEFuture

### DIFF
--- a/src/driver/send_zc.rs
+++ b/src/driver/send_zc.rs
@@ -5,6 +5,7 @@ use crate::{
     BufResult,
 };
 use std::io;
+use crate::driver::op::MultiCQEFuture;
 
 pub(crate) struct SendZc<T> {
     /// Holds a strong ref to the FD, preventing the file from being closed
@@ -18,8 +19,8 @@ pub(crate) struct SendZc<T> {
     bytes: usize,
 }
 
-impl<T: IoBuf> Op<SendZc<T>> {
-    pub(crate) fn send_zc(fd: &SharedFd, buf: T) -> io::Result<Op<SendZc<T>>> {
+impl<T: IoBuf> Op<SendZc<T>, MultiCQEFuture> {
+    pub(crate) fn send_zc(fd: &SharedFd, buf: T) -> io::Result<Self> {
         use io_uring::{opcode, types};
 
         Op::submit_with(

--- a/src/driver/send_zc.rs
+++ b/src/driver/send_zc.rs
@@ -1,11 +1,10 @@
-use crate::driver::op::{self, Completable, Updateable};
+use crate::driver::op::{self, Completable, MultiCQEFuture, Updateable};
 use crate::{
     buf::IoBuf,
     driver::{Op, SharedFd},
     BufResult,
 };
 use std::io;
-use crate::driver::op::MultiCQEFuture;
 
 pub(crate) struct SendZc<T> {
     /// Holds a strong ref to the FD, preventing the file from being closed


### PR DESCRIPTION
Somewhere, in the myriad of refactorings that occurred in #123, I dropped the marker type. This leads to wrongly associating the Future for handling SingleCQE types with SendZc, which is a multi completion type.