### PR TITLE
Expose `buf_index`

### DIFF
--- a/src/buf/fixed/handle.rs
+++ b/src/buf/fixed/handle.rs
@@ -54,7 +54,7 @@ impl FixedBuf {
             index,
         }
     }
-    
+
     /// Index of the underlying registry buffer
     pub fn buf_index(&self) -> u16 {
         self.index

--- a/src/buf/fixed/handle.rs
+++ b/src/buf/fixed/handle.rs
@@ -54,8 +54,9 @@ impl FixedBuf {
             index,
         }
     }
-
-    pub(crate) fn buf_index(&self) -> u16 {
+    
+    /// Index of the underlying registry buffer
+    pub fn buf_index(&self) -> u16 {
         self.index
     }
 }


### PR DESCRIPTION
This makes it easier to build abstractions on top of the `FixedBufferRegistry`. I can work around this not being exposed it but it's a bit unnecessary to track the same information in multiple places and I don't see a reason from hiding this information from the users in the first place.