### PR TITLE
use std::future::poll_fn

### DIFF
--- a/src/future.rs
+++ b/src/future.rs
@@ -1,7 +1,3 @@
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-
 macro_rules! ready {
     ($e:expr $(,)?) => {
         match $e {
@@ -9,29 +5,4 @@ macro_rules! ready {
             std::task::Poll::Pending => return std::task::Poll::Pending,
         }
     };
-}
-
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub(crate) struct PollFn<F> {
-    f: F,
-}
-
-impl<F> Unpin for PollFn<F> {}
-
-pub(crate) fn poll_fn<T, F>(f: F) -> PollFn<F>
-where
-    F: FnMut(&mut Context<'_>) -> Poll<T>,
-{
-    PollFn { f }
-}
-
-impl<T, F> Future for PollFn<F>
-where
-    F: FnMut(&mut Context<'_>) -> Poll<T>,
-{
-    type Output = T;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        (self.f)(cx)
-    }
 }

--- a/src/io/shared_fd.rs
+++ b/src/io/shared_fd.rs
@@ -1,5 +1,5 @@
-use crate::future::poll_fn;
 use crate::io::Close;
+use std::future::poll_fn;
 
 use std::cell::RefCell;
 use std::os::unix::io::{FromRawFd, RawFd};

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -104,7 +104,7 @@ impl Runtime {
         tokio::pin!(future);
 
         self.rt
-            .block_on(self.local.run_until(crate::future::poll_fn(|cx| {
+            .block_on(self.local.run_until(std::future::poll_fn(|cx| {
                 // assert!(drive.as_mut().poll(cx).is_pending());
                 future.as_mut().poll(cx)
             })))

--- a/tests/driver.rs
+++ b/tests/driver.rs
@@ -133,7 +133,7 @@ async fn poll_once(future: impl std::future::Future) {
 
     pin!(future);
 
-    future::poll_fn(|cx| {
+    std::future::poll_fn(|cx| {
         assert!(future.as_mut().poll(cx).is_pending());
         Poll::Ready(())
     })

--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -287,7 +287,7 @@ fn tempfile() -> NamedTempFile {
 }
 
 async fn poll_once(future: impl std::future::Future) {
-    use future::poll_fn;
+    use std::future::poll_fn;
     // use std::future::Future;
     use std::task::Poll;
     use tokio::pin;


### PR DESCRIPTION
No need for this crate to maintain its own any longer.

There was recent activity in the standard library around this, https://github.com/rust-lang/rust/pull/102737 .