### PR TITLE
rt: refactor driver, runtime, and op

### DIFF
--- a/src/buf/fixed/pool.rs
+++ b/src/buf/fixed/pool.rs
@@ -152,12 +152,7 @@ impl FixedBufPool {
     pub fn new(bufs: impl IntoIterator<Item = Vec<u8>>) -> Self {
         FixedBufPool {
             inner: Rc::new(RefCell::new(Inner::new(bufs.into_iter()))),
-            driver: CONTEXT.with(|x| {
-                x.handle()
-                    .as_ref()
-                    .expect("Not in a runtime context")
-                    .into()
-            }),
+            driver: CONTEXT.with(|x| x.weak().expect("Not in a runtime context")),
         }
     }
 

--- a/src/buf/fixed/registry.rs
+++ b/src/buf/fixed/registry.rs
@@ -106,12 +106,7 @@ impl FixedBufRegistry {
     pub fn new(bufs: impl IntoIterator<Item = Vec<u8>>) -> Self {
         FixedBufRegistry {
             inner: Rc::new(RefCell::new(Inner::new(bufs.into_iter()))),
-            driver: CONTEXT.with(|x| {
-                x.handle()
-                    .as_ref()
-                    .expect("Not in a runtime context")
-                    .into()
-            }),
+            driver: CONTEXT.with(|x| x.weak().expect("Not in a runtime context")),
         }
     }
 

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -1,5 +1,5 @@
 use crate::runtime::driver;
-use crate::runtime::driver::Handle;
+use crate::runtime::driver::{Handle, WeakHandle};
 use std::cell::RefCell;
 
 /// Owns the driver and resides in thread-local storage.
@@ -44,17 +44,7 @@ impl RuntimeContext {
         self.driver.borrow().clone()
     }
 
-    /// Execute a function which requires mutable access to the driver.
-    pub(crate) fn with_handle_mut<F, R>(&self, f: F) -> R
-    where
-        F: FnOnce(&mut driver::Handle) -> R,
-    {
-        let mut guard = self.driver.borrow_mut();
-
-        let driver = guard
-            .as_mut()
-            .expect("Attempted to access driver in invalid context");
-
-        f(driver)
+    pub(crate) fn weak(&self) -> Option<WeakHandle> {
+        self.driver.borrow().as_ref().map(Into::into)
     }
 }

--- a/src/runtime/driver/handle.rs
+++ b/src/runtime/driver/handle.rs
@@ -12,15 +12,16 @@
 //! The weak handle should be used by anything which is stored in the driver or does not need to
 //! keep the driver alive for it's duration.
 
-use io_uring::{cqueue, squeue};
+use io_uring::squeue;
 use std::cell::RefCell;
 use std::io;
+use std::ops::Deref;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::rc::{Rc, Weak};
 use std::task::{Context, Poll};
 
 use crate::buf::fixed::FixedBuffers;
-use crate::runtime::driver::op::{Completable, Lifecycle, MultiCQEFuture, Op, Updateable};
+use crate::runtime::driver::op::{Completable, MultiCQEFuture, Op, Updateable};
 use crate::runtime::driver::Driver;
 
 #[derive(Clone)]
@@ -40,8 +41,8 @@ impl Handle {
         })
     }
 
-    pub(crate) fn tick(&self) {
-        self.inner.borrow_mut().tick()
+    pub(crate) fn dispatch_completions(&self) {
+        self.inner.borrow_mut().dispatch_completions()
     }
 
     pub(crate) fn flush(&self) -> io::Result<usize> {
@@ -52,99 +53,29 @@ impl Handle {
         &self,
         buffers: Rc<RefCell<dyn FixedBuffers>>,
     ) -> io::Result<()> {
-        let mut driver = self.inner.borrow_mut();
-
-        driver
-            .uring
-            .submitter()
-            .register_buffers(buffers.borrow().iovecs())?;
-
-        driver.fixed_buffers = Some(buffers);
-        Ok(())
+        self.inner.borrow_mut().register_buffers(buffers)
     }
 
     pub(crate) fn unregister_buffers(
         &self,
         buffers: Rc<RefCell<dyn FixedBuffers>>,
     ) -> io::Result<()> {
-        let mut driver = self.inner.borrow_mut();
-
-        if let Some(currently_registered) = &driver.fixed_buffers {
-            if Rc::ptr_eq(&buffers, currently_registered) {
-                driver.uring.submitter().unregister_buffers()?;
-                driver.fixed_buffers = None;
-                return Ok(());
-            }
-        }
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "fixed buffers are not currently registered",
-        ))
+        self.inner.borrow_mut().unregister_buffers(buffers)
     }
 
-    /// Submit an operation to uring.
-    ///
-    /// `state` is stored during the operation tracking any state submitted to
-    /// the kernel.
-    pub(crate) fn submit_op<T, S, F>(&self, mut data: T, f: F) -> io::Result<Op<T, S>>
+    pub(crate) fn submit_op<T, S, F>(&self, data: T, f: F) -> io::Result<Op<T, S>>
     where
         T: Completable,
         F: FnOnce(&mut T) -> squeue::Entry,
     {
-        let mut driver = self.inner.borrow_mut();
-        let index = driver.ops.insert();
-
-        // Configure the SQE
-        let sqe = f(&mut data).user_data(index as _);
-
-        // Create the operation
-        let op = Op::new(self.into(), data, index);
-
-        // Push the new operation
-        while unsafe { driver.uring.submission().push(&sqe).is_err() } {
-            // If the submission queue is full, flush it to the kernel
-            driver.submit()?;
-        }
-
-        Ok(op)
+        self.inner.borrow_mut().submit_op(data, f, self.into())
     }
 
     pub(crate) fn poll_op<T>(&self, op: &mut Op<T>, cx: &mut Context<'_>) -> Poll<T::Output>
     where
         T: Unpin + 'static + Completable,
     {
-        use std::mem;
-
-        let mut driver = self.inner.borrow_mut();
-
-        let (lifecycle, _) = driver
-            .ops
-            .get_mut(op.index)
-            .expect("invalid internal state");
-
-        match mem::replace(lifecycle, Lifecycle::Submitted) {
-            Lifecycle::Submitted => {
-                *lifecycle = Lifecycle::Waiting(cx.waker().clone());
-                Poll::Pending
-            }
-            Lifecycle::Waiting(waker) if !waker.will_wake(cx.waker()) => {
-                *lifecycle = Lifecycle::Waiting(cx.waker().clone());
-                Poll::Pending
-            }
-            Lifecycle::Waiting(waker) => {
-                *lifecycle = Lifecycle::Waiting(waker);
-                Poll::Pending
-            }
-            Lifecycle::Ignored(..) => unreachable!(),
-            Lifecycle::Completed(cqe) => {
-                driver.ops.remove(op.index);
-                op.index = usize::MAX;
-                Poll::Ready(op.data.take().unwrap().complete(cqe))
-            }
-            Lifecycle::CompletionList(..) => {
-                unreachable!("No `more` flag set for SingleCQE")
-            }
-        }
+        self.inner.borrow_mut().poll_op(op, cx)
     }
 
     pub(crate) fn poll_multishot_op<T>(
@@ -155,103 +86,11 @@ impl Handle {
     where
         T: Unpin + 'static + Completable + Updateable,
     {
-        use std::mem;
-
-        let mut driver = self.inner.borrow_mut();
-
-        let (lifecycle, completions) = driver
-            .ops
-            .get_mut(op.index)
-            .expect("invalid internal state");
-
-        match mem::replace(lifecycle, Lifecycle::Submitted) {
-            Lifecycle::Submitted => {
-                *lifecycle = Lifecycle::Waiting(cx.waker().clone());
-                Poll::Pending
-            }
-            Lifecycle::Waiting(waker) if !waker.will_wake(cx.waker()) => {
-                *lifecycle = Lifecycle::Waiting(cx.waker().clone());
-                Poll::Pending
-            }
-            Lifecycle::Waiting(waker) => {
-                *lifecycle = Lifecycle::Waiting(waker);
-                Poll::Pending
-            }
-            Lifecycle::Ignored(..) => unreachable!(),
-            Lifecycle::Completed(cqe) => {
-                // This is possible. We may have previously polled a CompletionList,
-                // and the final CQE registered as Completed
-                driver.ops.remove(op.index);
-                op.index = usize::MAX;
-                Poll::Ready(op.data.take().unwrap().complete(cqe))
-            }
-            Lifecycle::CompletionList(indices) => {
-                let mut data = op.data.take().unwrap();
-                let mut status = Poll::Pending;
-                // Consume the CqeResult list, calling update on the Op on all Cqe's flagged `more`
-                // If the final Cqe is present, clean up and return Poll::Ready
-                for cqe in indices.into_list(completions) {
-                    if cqueue::more(cqe.flags) {
-                        data.update(cqe);
-                    } else {
-                        status = Poll::Ready(cqe);
-                        break;
-                    }
-                }
-                match status {
-                    Poll::Pending => {
-                        // We need more CQE's. Restore the op state
-                        let _ = op.data.insert(data);
-                        *lifecycle = Lifecycle::Waiting(cx.waker().clone());
-                        Poll::Pending
-                    }
-                    Poll::Ready(cqe) => {
-                        driver.ops.remove(op.index);
-                        op.index = usize::MAX;
-                        Poll::Ready(data.complete(cqe))
-                    }
-                }
-            }
-        }
+        self.inner.borrow_mut().poll_multishot_op(op, cx)
     }
 
     pub(crate) fn remove_op<T, CqeType>(&self, op: &mut Op<T, CqeType>) {
-        use std::mem;
-
-        let mut driver = self.inner.borrow_mut();
-
-        // Get the Op Lifecycle state from the driver
-        let (lifecycle, completions) = match driver.ops.get_mut(op.index) {
-            Some(val) => val,
-            None => {
-                // Op dropped after the driver
-                return;
-            }
-        };
-
-        match mem::replace(lifecycle, Lifecycle::Submitted) {
-            Lifecycle::Submitted | Lifecycle::Waiting(_) => {
-                *lifecycle = Lifecycle::Ignored(Box::new(op.data.take()));
-            }
-            Lifecycle::Completed(..) => {
-                driver.ops.remove(op.index);
-            }
-            Lifecycle::CompletionList(indices) => {
-                // Deallocate list entries, recording if more CQE's are expected
-                let more = {
-                    let mut list = indices.into_list(completions);
-                    cqueue::more(list.peek_end().unwrap().flags)
-                    // Dropping list deallocates the list entries
-                };
-                if more {
-                    // If more are expected, we have to keep the op around
-                    *lifecycle = Lifecycle::Ignored(Box::new(op.data.take()));
-                } else {
-                    driver.ops.remove(op.index);
-                }
-            }
-            Lifecycle::Ignored(..) => unreachable!(),
-        }
+        self.inner.borrow_mut().remove_op(op)
     }
 }
 
@@ -277,8 +116,11 @@ impl From<Driver> for Handle {
     }
 }
 
-impl From<&Handle> for WeakHandle {
-    fn from(handle: &Handle) -> Self {
+impl<T> From<T> for WeakHandle
+where
+    T: Deref<Target = Handle>,
+{
+    fn from(handle: T) -> Self {
         Self {
             inner: Rc::downgrade(&handle.inner),
         }

--- a/src/runtime/driver/mod.rs
+++ b/src/runtime/driver/mod.rs
@@ -235,7 +235,7 @@ impl Driver {
                 match status {
                     Poll::Pending => {
                         // We need more CQE's. Restore the op state
-                        let _ = op.insert_data(data);
+                        op.insert_data(data);
                         *lifecycle = Lifecycle::Waiting(cx.waker().clone());
                         Poll::Pending
                     }

--- a/src/runtime/driver/mod.rs
+++ b/src/runtime/driver/mod.rs
@@ -1,12 +1,13 @@
 use crate::buf::fixed::FixedBuffers;
-use crate::runtime::driver::op::Lifecycle;
+use crate::runtime::driver::op::{Completable, Lifecycle, MultiCQEFuture, Op, Updateable};
 use io_uring::opcode::AsyncCancel;
-use io_uring::IoUring;
+use io_uring::{cqueue, squeue, IoUring};
 use slab::Slab;
 use std::cell::RefCell;
 use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::rc::Rc;
+use std::task::{Context, Poll};
 
 pub(crate) use handle::*;
 
@@ -18,12 +19,12 @@ pub(crate) struct Driver {
     ops: Ops,
 
     /// IoUring bindings
-    pub(crate) uring: IoUring,
+    uring: IoUring,
 
     /// Reference to the currently registered buffers.
     /// Ensures that the buffers are not dropped until
     /// after the io-uring runtime has terminated.
-    pub(crate) fixed_buffers: Option<Rc<RefCell<dyn FixedBuffers>>>,
+    fixed_buffers: Option<Rc<RefCell<dyn FixedBuffers>>>,
 }
 
 struct Ops {
@@ -56,7 +57,7 @@ impl Driver {
         self.ops.lifecycle.len()
     }
 
-    pub(crate) fn tick(&mut self) {
+    pub(crate) fn dispatch_completions(&mut self) {
         let mut cq = self.uring.completion();
         cq.sync();
 
@@ -82,13 +83,205 @@ impl Driver {
                     return Ok(());
                 }
                 Err(ref e) if e.raw_os_error() == Some(libc::EBUSY) => {
-                    self.tick();
+                    self.dispatch_completions();
                 }
                 Err(e) if e.raw_os_error() != Some(libc::EINTR) => {
                     return Err(e);
                 }
                 _ => continue,
             }
+        }
+    }
+
+    pub(crate) fn register_buffers(
+        &mut self,
+        buffers: Rc<RefCell<dyn FixedBuffers>>,
+    ) -> io::Result<()> {
+        self.uring
+            .submitter()
+            .register_buffers(buffers.borrow().iovecs())?;
+
+        self.fixed_buffers = Some(buffers);
+        Ok(())
+    }
+
+    pub(crate) fn unregister_buffers(
+        &mut self,
+        buffers: Rc<RefCell<dyn FixedBuffers>>,
+    ) -> io::Result<()> {
+        if let Some(currently_registered) = &self.fixed_buffers {
+            if Rc::ptr_eq(&buffers, currently_registered) {
+                self.uring.submitter().unregister_buffers()?;
+                self.fixed_buffers = None;
+                return Ok(());
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            "fixed buffers are not currently registered",
+        ))
+    }
+
+    pub(crate) fn submit_op<T, S, F>(
+        &mut self,
+        mut data: T,
+        f: F,
+        handle: WeakHandle,
+    ) -> io::Result<Op<T, S>>
+    where
+        T: Completable,
+        F: FnOnce(&mut T) -> squeue::Entry,
+    {
+        let index = self.ops.insert();
+
+        // Configure the SQE
+        let sqe = f(&mut data).user_data(index as _);
+
+        // Create the operation
+        let op = Op::new(handle, data, index);
+
+        // Push the new operation
+        while unsafe { self.uring.submission().push(&sqe).is_err() } {
+            // If the submission queue is full, flush it to the kernel
+            self.submit()?;
+        }
+
+        Ok(op)
+    }
+
+    pub(crate) fn poll_op<T>(&mut self, op: &mut Op<T>, cx: &mut Context<'_>) -> Poll<T::Output>
+    where
+        T: Unpin + 'static + Completable,
+    {
+        use std::mem;
+
+        let (lifecycle, _) = self
+            .ops
+            .get_mut(op.index())
+            .expect("invalid internal state");
+
+        match mem::replace(lifecycle, Lifecycle::Submitted) {
+            Lifecycle::Submitted => {
+                *lifecycle = Lifecycle::Waiting(cx.waker().clone());
+                Poll::Pending
+            }
+            Lifecycle::Waiting(waker) if !waker.will_wake(cx.waker()) => {
+                *lifecycle = Lifecycle::Waiting(cx.waker().clone());
+                Poll::Pending
+            }
+            Lifecycle::Waiting(waker) => {
+                *lifecycle = Lifecycle::Waiting(waker);
+                Poll::Pending
+            }
+            Lifecycle::Ignored(..) => unreachable!(),
+            Lifecycle::Completed(cqe) => {
+                self.ops.remove(op.index());
+                Poll::Ready(op.take_data().unwrap().complete(cqe))
+            }
+            Lifecycle::CompletionList(..) => {
+                unreachable!("No `more` flag set for SingleCQE")
+            }
+        }
+    }
+
+    pub(crate) fn poll_multishot_op<T>(
+        &mut self,
+        op: &mut Op<T, MultiCQEFuture>,
+        cx: &mut Context<'_>,
+    ) -> Poll<T::Output>
+    where
+        T: Unpin + 'static + Completable + Updateable,
+    {
+        use std::mem;
+
+        let (lifecycle, completions) = self
+            .ops
+            .get_mut(op.index())
+            .expect("invalid internal state");
+
+        match mem::replace(lifecycle, Lifecycle::Submitted) {
+            Lifecycle::Submitted => {
+                *lifecycle = Lifecycle::Waiting(cx.waker().clone());
+                Poll::Pending
+            }
+            Lifecycle::Waiting(waker) if !waker.will_wake(cx.waker()) => {
+                *lifecycle = Lifecycle::Waiting(cx.waker().clone());
+                Poll::Pending
+            }
+            Lifecycle::Waiting(waker) => {
+                *lifecycle = Lifecycle::Waiting(waker);
+                Poll::Pending
+            }
+            Lifecycle::Ignored(..) => unreachable!(),
+            Lifecycle::Completed(cqe) => {
+                // This is possible. We may have previously polled a CompletionList,
+                // and the final CQE registered as Completed
+                self.ops.remove(op.index());
+                Poll::Ready(op.take_data().unwrap().complete(cqe))
+            }
+            Lifecycle::CompletionList(indices) => {
+                let mut data = op.take_data().unwrap();
+                let mut status = Poll::Pending;
+                // Consume the CqeResult list, calling update on the Op on all Cqe's flagged `more`
+                // If the final Cqe is present, clean up and return Poll::Ready
+                for cqe in indices.into_list(completions) {
+                    if cqueue::more(cqe.flags) {
+                        data.update(cqe);
+                    } else {
+                        status = Poll::Ready(cqe);
+                        break;
+                    }
+                }
+                match status {
+                    Poll::Pending => {
+                        // We need more CQE's. Restore the op state
+                        let _ = op.insert_data(data);
+                        *lifecycle = Lifecycle::Waiting(cx.waker().clone());
+                        Poll::Pending
+                    }
+                    Poll::Ready(cqe) => {
+                        self.ops.remove(op.index());
+                        Poll::Ready(data.complete(cqe))
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) fn remove_op<T, CqeType>(&mut self, op: &mut Op<T, CqeType>) {
+        use std::mem;
+
+        // Get the Op Lifecycle state from the driver
+        let (lifecycle, completions) = match self.ops.get_mut(op.index()) {
+            Some(val) => val,
+            None => {
+                // Op dropped after the driver
+                return;
+            }
+        };
+
+        match mem::replace(lifecycle, Lifecycle::Submitted) {
+            Lifecycle::Submitted | Lifecycle::Waiting(_) => {
+                *lifecycle = Lifecycle::Ignored(Box::new(op.take_data()));
+            }
+            Lifecycle::Completed(..) => {
+                self.ops.remove(op.index());
+            }
+            Lifecycle::CompletionList(indices) => {
+                // Deallocate list entries, recording if more CQE's are expected
+                let more = {
+                    let mut list = indices.into_list(completions);
+                    cqueue::more(list.peek_end().unwrap().flags)
+                    // Dropping list deallocates the list entries
+                };
+                if more {
+                    // If more are expected, we have to keep the op around
+                    *lifecycle = Lifecycle::Ignored(Box::new(op.take_data()));
+                } else {
+                    self.ops.remove(op.index());
+                }
+            }
+            Lifecycle::Ignored(..) => unreachable!(),
         }
     }
 }
@@ -179,7 +372,7 @@ impl Drop for Driver {
                     // If waiting fails, ignore the error. The wait will be attempted
                     // again on the next loop.
                     let _ = self.wait();
-                    self.tick();
+                    self.dispatch_completions();
                 }
 
                 Some(_) => {
@@ -370,7 +563,7 @@ mod test {
     #[test]
     fn complete_after_drop() {
         let (op, data) = init();
-        let index = op.index;
+        let index = op.index();
         drop(op);
 
         assert_eq!(2, Rc::strong_count(&data));
@@ -383,7 +576,12 @@ mod test {
         };
 
         CONTEXT.with(|cx| {
-            cx.with_handle_mut(|driver| driver.inner.borrow_mut().ops.complete(index, cqe))
+            cx.handle()
+                .unwrap()
+                .inner
+                .borrow_mut()
+                .ops
+                .complete(index, cqe)
         });
 
         assert_eq!(1, Rc::strong_count(&data));
@@ -399,33 +597,36 @@ mod test {
         let op = CONTEXT.with(|cx| {
             cx.set_handle(driver.into());
 
-            cx.with_handle_mut(|driver| {
-                let index = driver.inner.borrow_mut().ops.insert();
+            let driver = cx.handle().unwrap();
 
-                Op::new((&*driver).into(), data.clone(), index)
-            })
+            let index = driver.inner.borrow_mut().ops.insert();
+
+            Op::new((&driver).into(), data.clone(), index)
         });
 
         (op, data)
     }
 
     fn num_operations() -> usize {
-        CONTEXT.with(|cx| cx.with_handle_mut(|driver| driver.inner.borrow().num_operations()))
+        CONTEXT.with(|cx| cx.handle().unwrap().inner.borrow().num_operations())
     }
 
     fn complete(op: &Op<Rc<()>>, result: io::Result<u32>) {
         let cqe = CqeResult { result, flags: 0 };
+
         CONTEXT.with(|cx| {
-            cx.with_handle_mut(|driver| driver.inner.borrow_mut().ops.complete(op.index, cqe))
+            let driver = cx.handle().unwrap();
+
+            driver.inner.borrow_mut().ops.complete(op.index(), cqe);
         });
     }
 
     fn release() {
         CONTEXT.with(|cx| {
-            cx.with_handle_mut(|driver| {
-                driver.inner.borrow_mut().ops.lifecycle.clear();
-                driver.inner.borrow_mut().ops.completions.clear();
-            });
+            let driver = cx.handle().unwrap();
+
+            driver.inner.borrow_mut().ops.lifecycle.clear();
+            driver.inner.borrow_mut().ops.completions.clear();
 
             cx.unset_driver();
         });

--- a/src/runtime/driver/op/mod.rs
+++ b/src/runtime/driver/op/mod.rs
@@ -24,10 +24,10 @@ pub(crate) type Completion = SlabListEntry<CqeResult>;
 pub(crate) struct Op<T: 'static, CqeType = SingleCQE> {
     driver: driver::WeakHandle,
     // Operation index in the slab
-    pub(crate) index: usize,
+    index: usize,
 
     // Per-operation data
-    pub(crate) data: Option<T>,
+    data: Option<T>,
 
     // CqeType marker
     _cqe_type: PhantomData<CqeType>,
@@ -90,18 +90,27 @@ impl From<cqueue::Entry> for CqeResult {
     }
 }
 
-impl<T, CqeType> Op<T, CqeType>
-where
-    T: Completable,
-{
+impl<T, CqeType> Op<T, CqeType> {
     /// Create a new operation
-    pub(crate) fn new(driver: driver::WeakHandle, data: T, index: usize) -> Self {
+    pub(super) fn new(driver: driver::WeakHandle, data: T, index: usize) -> Self {
         Op {
             driver,
             index,
             data: Some(data),
             _cqe_type: PhantomData,
         }
+    }
+
+    pub(super) fn index(&self) -> usize {
+        self.index
+    }
+
+    pub(super) fn take_data(&mut self) -> Option<T> {
+        self.data.take()
+    }
+
+    pub(super) fn insert_data(&mut self, data: T) {
+        self.data = Some(data);
     }
 }
 


### PR DESCRIPTION
This cleans up a few different pieces and is a followup change from #196.