### PR TITLE
Add method `BoundedBuf::put_slice`

### DIFF
--- a/src/buf/bounded.rs
+++ b/src/buf/bounded.rs
@@ -154,7 +154,7 @@ pub trait BoundedBufMut: BoundedBuf<Buf = Self::BufMut> {
     /// to `pos` are initialized and owned by the buffer.
     unsafe fn set_init(&mut self, pos: usize);
 
-    /// Copies the given byte slice slice into the buffer, starting at
+    /// Copies the given byte slice into the buffer, starting at
     /// this view's offset.
     ///
     /// # Panics

--- a/src/buf/bounded.rs
+++ b/src/buf/bounded.rs
@@ -1,6 +1,7 @@
 use super::{IoBuf, IoBufMut, Slice};
 
 use std::ops;
+use std::ptr;
 
 /// A possibly bounded view into an owned [`IoBuf`] buffer.
 ///
@@ -152,6 +153,29 @@ pub trait BoundedBufMut: BoundedBuf<Buf = Self::BufMut> {
     /// The caller must ensure that all bytes starting at `stable_mut_ptr()` up
     /// to `pos` are initialized and owned by the buffer.
     unsafe fn set_init(&mut self, pos: usize);
+
+    /// Copies the given byte slice slice into the buffer, starting at
+    /// this view's offset.
+    ///
+    /// # Panics
+    ///
+    /// If the slice's length exceeds the destination's total capacity,
+    /// this method panics.
+    fn put_slice(&mut self, src: &[u8]) {
+        assert!(self.bytes_total() >= src.len());
+        let dst = self.stable_mut_ptr();
+
+        // Safety:
+        // dst pointer validity is ensured by stable_mut_ptr;
+        // the length is checked to not exceed the view's total capacity;
+        // src (immutable) and dst (mutable) cannot point to overlapping memory;
+        // after copying the amount of bytes given by the slice, it's safe
+        // to mark them as initialized in the buffer.
+        unsafe {
+            ptr::copy_nonoverlapping(src.as_ptr(), dst, src.len());
+            self.set_init(src.len());
+        }
+    }
 }
 
 impl<T: IoBufMut> BoundedBufMut for T {

--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -1,7 +1,6 @@
 use std::{
     io::prelude::*,
     os::unix::io::{AsRawFd, FromRawFd, RawFd},
-    ptr,
 };
 
 use tempfile::NamedTempFile;
@@ -263,7 +262,7 @@ fn write_fixed() {
 
         let fixed_buf = buffers.check_out(0).unwrap();
         let mut buf = fixed_buf;
-        push_slice_to_buf(&HELLO[..6], &mut buf);
+        buf.put_slice(&HELLO[..6]);
 
         let (res, _) = file.write_fixed_at(buf, 0).await;
         let n = res.unwrap();
@@ -271,7 +270,7 @@ fn write_fixed() {
 
         let fixed_buf = buffers.check_out(1).unwrap();
         let mut buf = fixed_buf;
-        push_slice_to_buf(&HELLO[6..], &mut buf);
+        buf.put_slice(&HELLO[6..]);
 
         let (res, _) = file.write_fixed_at(buf, 6).await;
         let n = res.unwrap();
@@ -310,14 +309,5 @@ fn assert_invalid_fd(fd: RawFd) {
     match f.read_to_end(&mut buf) {
         Err(ref e) if e.raw_os_error() == Some(libc::EBADF) => {}
         res => panic!("{:?}", res),
-    }
-}
-
-fn push_slice_to_buf(src: &[u8], buf: &mut impl BoundedBufMut) {
-    assert!(buf.bytes_total() >= src.len());
-    let dst = buf.stable_mut_ptr();
-    unsafe {
-        ptr::copy_nonoverlapping(src.as_ptr(), dst, src.len());
-        buf.set_init(src.len());
     }
 }


### PR DESCRIPTION
Provide a generic,  safe way to copy data into a buffer, possibly advancing the initialized length watermark.
This method is especially useful for `FixedBuf`, which lacks other population methods available for the foreign types.

This resolves a discussion started in https://github.com/tokio-rs/tokio-uring/pull/190#issuecomment-1336301837