### PR TITLE
`FixedBufPool::next`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["async", "fs", "io-uring"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.2", features = ["net", "rt"] }
+tokio = { version = "1.2", features = ["net", "rt", "sync"] }
 slab = "0.4.2"
 libc = "0.2.80"
 io-uring = { version = "0.5.9", features = ["unstable"] }

--- a/src/buf/fixed/handle.rs
+++ b/src/buf/fixed/handle.rs
@@ -9,7 +9,7 @@ use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 
 // Data to construct a `FixedBuf` handle from.
-pub(super) struct CheckedOutBuf {
+pub(crate) struct CheckedOutBuf {
     // Pointer and size of the buffer.
     pub iovec: iovec,
     // Length of the initialized part.

--- a/src/buf/fixed/mod.rs
+++ b/src/buf/fixed/mod.rs
@@ -21,6 +21,8 @@ pub use handle::FixedBuf;
 mod buffers;
 pub(crate) use buffers::FixedBuffers;
 
+mod plumbing;
+
 mod pool;
 pub use pool::FixedBufPool;
 

--- a/src/buf/fixed/mod.rs
+++ b/src/buf/fixed/mod.rs
@@ -23,7 +23,7 @@ pub(crate) use buffers::FixedBuffers;
 
 mod plumbing;
 
-mod pool;
+pub mod pool;
 pub use pool::FixedBufPool;
 
 mod registry;

--- a/src/buf/fixed/plumbing/mod.rs
+++ b/src/buf/fixed/plumbing/mod.rs
@@ -1,0 +1,8 @@
+// Internal data structures shared between thread-local and thread-safe
+// fixed buffer collections.
+
+mod pool;
+pub(super) use pool::Pool;
+
+mod registry;
+pub(super) use registry::Registry;

--- a/src/buf/fixed/plumbing/pool.rs
+++ b/src/buf/fixed/plumbing/pool.rs
@@ -23,7 +23,7 @@ pub(crate) struct Pool {
     states: Vec<BufState>,
     // Table of head indices of the free buffer lists in each size bucket.
     free_buf_head_by_cap: HashMap<usize, u16>,
-    // Used to notify tasks pending on Next
+    // Used to notify tasks pending on `next`
     notify_next_by_cap: HashMap<usize, Arc<Notify>>,
 }
 

--- a/src/buf/fixed/plumbing/pool.rs
+++ b/src/buf/fixed/plumbing/pool.rs
@@ -120,6 +120,8 @@ impl Pool {
         })
     }
 
+    // Returns a `Notify` to use for waking up tasks awaiting a buffer of
+    // the specified capacity.
     pub(crate) fn notify_on_next(&mut self, cap: usize) -> Arc<Notify> {
         let notify = self.notify_next_by_cap.entry(cap).or_default();
         Arc::clone(notify)

--- a/src/buf/fixed/plumbing/pool.rs
+++ b/src/buf/fixed/plumbing/pool.rs
@@ -1,0 +1,164 @@
+use crate::buf::fixed::{handle::CheckedOutBuf, FixedBuffers};
+
+use libc::{iovec, UIO_MAXIOV};
+use std::cmp;
+use std::collections::HashMap;
+use std::mem;
+use std::ptr;
+use std::slice;
+
+// Internal state shared by FixedBufPool and FixedBuf handles.
+pub(crate) struct Pool {
+    // Pointer to an allocated array of iovec records referencing
+    // the allocated buffers. The number of initialized records is the
+    // same as the length of the states array.
+    raw_bufs: ptr::NonNull<iovec>,
+    // Original capacity of raw_bufs as a Vec.
+    orig_cap: usize,
+    // State information on the buffers. Indices in this array correspond to
+    // the indices in the array at raw_bufs.
+    states: Vec<BufState>,
+    // Table of head indices of the free buffer lists in each size bucket.
+    free_buf_head_by_cap: HashMap<usize, u16>,
+}
+
+// State information of a buffer in the registry,
+enum BufState {
+    // The buffer is not in use.
+    Free {
+        // This field records the length of the initialized part.
+        init_len: usize,
+        // Index of the next buffer of the same capacity in a free buffer list, if any.
+        next: Option<u16>,
+    },
+    // The buffer is checked out.
+    // Its data are logically owned by the FixedBuf handle,
+    // which also keeps track of the length of the initialized part.
+    CheckedOut,
+}
+
+impl Pool {
+    pub(crate) fn new(bufs: impl Iterator<Item = Vec<u8>>) -> Self {
+        let bufs = bufs.take(cmp::min(UIO_MAXIOV as usize, u16::MAX as usize));
+        let (size_hint, _) = bufs.size_hint();
+        let mut iovecs = Vec::with_capacity(size_hint);
+        let mut states = Vec::with_capacity(size_hint);
+        let mut free_buf_head_by_cap = HashMap::new();
+        for (index, mut buf) in bufs.enumerate() {
+            let cap = buf.capacity();
+
+            // Link the buffer as the head of the free list for its capacity.
+            // This constructs the free buffer list to be initially retrieved
+            // back to front, which should be of no difference to the user.
+            let next = free_buf_head_by_cap.insert(cap, index as u16);
+
+            iovecs.push(iovec {
+                iov_base: buf.as_mut_ptr() as *mut _,
+                iov_len: cap,
+            });
+            states.push(BufState::Free {
+                init_len: buf.len(),
+                next,
+            });
+            mem::forget(buf);
+        }
+        debug_assert_eq!(iovecs.len(), states.len());
+
+        // Safety: Vec::as_mut_ptr never returns null
+        let raw_bufs = unsafe { ptr::NonNull::new_unchecked(iovecs.as_mut_ptr()) };
+        let orig_cap = iovecs.capacity();
+        mem::forget(iovecs);
+        Pool {
+            raw_bufs,
+            orig_cap,
+            states,
+            free_buf_head_by_cap,
+        }
+    }
+
+    // If the free buffer list for this capacity is not empty, checks out the first buffer
+    // from the list and returns its data. Otherwise, returns None.
+    pub(crate) fn try_next(&mut self, cap: usize) -> Option<CheckedOutBuf> {
+        let free_head = self.free_buf_head_by_cap.get_mut(&cap)?;
+        let index = *free_head as usize;
+        let state = &mut self.states[index];
+
+        let (init_len, next) = match *state {
+            BufState::Free { init_len, next } => {
+                *state = BufState::CheckedOut;
+                (init_len, next)
+            }
+            BufState::CheckedOut => panic!("buffer is checked out"),
+        };
+
+        // Update the head of the free list for this capacity.
+        match next {
+            Some(i) => {
+                *free_head = i;
+            }
+            None => {
+                self.free_buf_head_by_cap.remove(&cap);
+            }
+        }
+
+        // Safety: the allocated array under the pointer is valid
+        // for the lifetime of self, a free buffer index is inside the array,
+        // as also asserted by the indexing operation on the states array
+        // that has the same length.
+        let iovec = unsafe { self.raw_bufs.as_ptr().add(index).read() };
+        debug_assert_eq!(iovec.iov_len, cap);
+        Some(CheckedOutBuf {
+            iovec,
+            init_len,
+            index: index as u16,
+        })
+    }
+
+    fn check_in_internal(&mut self, index: u16, init_len: usize) {
+        let cap = self.iovecs()[index as usize].iov_len;
+        let state = &mut self.states[index as usize];
+        debug_assert!(
+            matches!(state, BufState::CheckedOut),
+            "the buffer must be checked out"
+        );
+
+        // Link the buffer as the new head of the free list for its capacity.
+        // Recently checked in buffers will be first to be reused,
+        // improving cache locality.
+        let next = self.free_buf_head_by_cap.insert(cap, index);
+
+        *state = BufState::Free { init_len, next };
+    }
+}
+
+impl FixedBuffers for Pool {
+    fn iovecs(&self) -> &[iovec] {
+        // Safety: the raw_bufs pointer is valid for the lifetime of self,
+        // the length of the states array is also the length of buffers array
+        // by construction.
+        unsafe { slice::from_raw_parts(self.raw_bufs.as_ptr(), self.states.len()) }
+    }
+
+    unsafe fn check_in(&mut self, index: u16, init_len: usize) {
+        self.check_in_internal(index, init_len)
+    }
+}
+
+impl Drop for Pool {
+    fn drop(&mut self) {
+        let iovecs = unsafe {
+            Vec::from_raw_parts(self.raw_bufs.as_ptr(), self.states.len(), self.orig_cap)
+        };
+        for (i, iovec) in iovecs.iter().enumerate() {
+            match self.states[i] {
+                BufState::Free { init_len, next: _ } => {
+                    let ptr = iovec.iov_base as *mut u8;
+                    let cap = iovec.iov_len;
+                    let v = unsafe { Vec::from_raw_parts(ptr, init_len, cap) };
+                    mem::drop(v);
+                }
+                BufState::CheckedOut => unreachable!("all buffers must be checked in"),
+            }
+        }
+    }
+}

--- a/src/buf/fixed/plumbing/registry.rs
+++ b/src/buf/fixed/plumbing/registry.rs
@@ -1,0 +1,129 @@
+use crate::buf::fixed::{handle::CheckedOutBuf, FixedBuffers};
+
+use libc::{iovec, UIO_MAXIOV};
+use std::cmp;
+use std::mem;
+use std::ptr;
+use std::slice;
+
+// Internal state shared by FixedBufRegistry and FixedBuf handles.
+pub(crate) struct Registry {
+    // Pointer to an allocated array of iovec records referencing
+    // the allocated buffers. The number of initialized records is the
+    // same as the length of the states array.
+    raw_bufs: ptr::NonNull<iovec>,
+    // Original capacity of raw_bufs as a Vec.
+    orig_cap: usize,
+    // State information on the buffers. Indices in this array correspond to
+    // the indices in the array at raw_bufs.
+    states: Vec<BufState>,
+}
+
+// State information of a buffer in the registry,
+enum BufState {
+    // The buffer is not in use.
+    // The field records the length of the initialized part.
+    Free { init_len: usize },
+    // The buffer is checked out.
+    // Its data are logically owned by the FixedBuf handle,
+    // which also keeps track of the length of the initialized part.
+    CheckedOut,
+}
+
+impl Registry {
+    pub(crate) fn new(bufs: impl Iterator<Item = Vec<u8>>) -> Self {
+        let bufs = bufs.take(cmp::min(UIO_MAXIOV as usize, u16::MAX as usize));
+        let (size_hint, _) = bufs.size_hint();
+        let mut iovecs = Vec::with_capacity(size_hint);
+        let mut states = Vec::with_capacity(size_hint);
+        for mut buf in bufs {
+            iovecs.push(iovec {
+                iov_base: buf.as_mut_ptr() as *mut _,
+                iov_len: buf.capacity(),
+            });
+            states.push(BufState::Free {
+                init_len: buf.len(),
+            });
+            mem::forget(buf);
+        }
+        debug_assert_eq!(iovecs.len(), states.len());
+
+        // Safety: Vec::as_mut_ptr never returns null
+        let raw_bufs = unsafe { ptr::NonNull::new_unchecked(iovecs.as_mut_ptr()) };
+        let orig_cap = iovecs.capacity();
+        mem::forget(iovecs);
+        Registry {
+            raw_bufs,
+            orig_cap,
+            states,
+        }
+    }
+
+    // If the indexed buffer is free, changes its state to checked out
+    // and returns its data.
+    // If the buffer is already checked out, returns None.
+    pub(crate) fn check_out(&mut self, index: usize) -> Option<CheckedOutBuf> {
+        let state = self.states.get_mut(index)?;
+        let BufState::Free { init_len } = *state else {
+            return None
+        };
+
+        *state = BufState::CheckedOut;
+
+        // Safety: the allocated array under the pointer is valid
+        // for the lifetime of self, the index is inside the array
+        // as checked by Vec::get_mut above, called on the array of
+        // states that has the same length.
+        let iovec = unsafe { self.raw_bufs.as_ptr().add(index).read() };
+        debug_assert!(index <= u16::MAX as usize);
+        Some(CheckedOutBuf {
+            iovec,
+            init_len,
+            index: index as u16,
+        })
+    }
+
+    fn check_in_internal(&mut self, index: u16, init_len: usize) {
+        let state = self
+            .states
+            .get_mut(index as usize)
+            .expect("invalid buffer index");
+        debug_assert!(
+            matches!(state, BufState::CheckedOut),
+            "the buffer must be checked out"
+        );
+        *state = BufState::Free { init_len };
+    }
+}
+
+impl FixedBuffers for Registry {
+    fn iovecs(&self) -> &[iovec] {
+        // Safety: the raw_bufs pointer is valid for the lifetime of self,
+        // the length of the states array is also the length of buffers array
+        // by construction.
+        unsafe { slice::from_raw_parts(self.raw_bufs.as_ptr(), self.states.len()) }
+    }
+
+    unsafe fn check_in(&mut self, index: u16, init_len: usize) {
+        self.check_in_internal(index, init_len)
+    }
+}
+
+impl Drop for Registry {
+    fn drop(&mut self) {
+        let iovecs = unsafe {
+            Vec::from_raw_parts(self.raw_bufs.as_ptr(), self.states.len(), self.orig_cap)
+        };
+        for (i, iovec) in iovecs.iter().enumerate() {
+            match self.states[i] {
+                BufState::Free { init_len } => {
+                    let ptr = iovec.iov_base as *mut u8;
+                    let cap = iovec.iov_len;
+                    let v = unsafe { Vec::from_raw_parts(ptr, init_len, cap) };
+                    mem::drop(v);
+                }
+                BufState::CheckedOut => unreachable!("all buffers must be checked in"),
+            }
+        }
+    }
+}

--- a/src/buf/fixed/pool.rs
+++ b/src/buf/fixed/pool.rs
@@ -230,10 +230,10 @@ impl FixedBufPool {
     pub fn try_next(&self, cap: usize) -> Option<FixedBuf> {
         let mut inner = self.inner.borrow_mut();
         inner.try_next(cap).map(|data| {
-            let registry = Rc::clone(&self.inner);
+            let pool = Rc::clone(&self.inner);
             // Safety: the validity of buffer data is ensured by
             // plumbing::Pool::try_next
-            unsafe { FixedBuf::new(registry, data) }
+            unsafe { FixedBuf::new(pool, data) }
         })
     }
 

--- a/src/buf/fixed/pool.rs
+++ b/src/buf/fixed/pool.rs
@@ -1,17 +1,11 @@
-use super::handle::CheckedOutBuf;
-use super::{FixedBuf, FixedBuffers};
+use super::plumbing;
+use super::FixedBuf;
 
 use crate::runtime::driver::WeakHandle;
 use crate::runtime::CONTEXT;
-use libc::{iovec, UIO_MAXIOV};
 use std::cell::RefCell;
-use std::cmp;
-use std::collections::HashMap;
 use std::io;
-use std::mem;
-use std::ptr;
 use std::rc::Rc;
-use std::slice;
 
 /// A dynamic collection of I/O buffers pre-registered with the kernel.
 ///
@@ -83,7 +77,7 @@ use std::slice;
 /// ```
 #[derive(Clone)]
 pub struct FixedBufPool {
-    inner: Rc<RefCell<Inner>>,
+    inner: Rc<RefCell<plumbing::Pool>>,
     driver: WeakHandle,
 }
 
@@ -151,7 +145,7 @@ impl FixedBufPool {
     /// ```
     pub fn new(bufs: impl IntoIterator<Item = Vec<u8>>) -> Self {
         FixedBufPool {
-            inner: Rc::new(RefCell::new(Inner::new(bufs.into_iter()))),
+            inner: Rc::new(RefCell::new(plumbing::Pool::new(bufs.into_iter()))),
             driver: CONTEXT.with(|x| {
                 x.handle()
                     .as_ref()
@@ -225,164 +219,8 @@ impl FixedBufPool {
         inner.try_next(cap).map(|data| {
             let registry = Rc::clone(&self.inner);
             // Safety: the validity of buffer data is ensured by
-            // Inner::try_next
+            // plumbing::Pool::try_next
             unsafe { FixedBuf::new(registry, data) }
         })
-    }
-}
-
-// Internal state shared by FixedBufPool and FixedBuf handles.
-struct Inner {
-    // Pointer to an allocated array of iovec records referencing
-    // the allocated buffers. The number of initialized records is the
-    // same as the length of the states array.
-    raw_bufs: ptr::NonNull<iovec>,
-    // State information on the buffers. Indices in this array correspond to
-    // the indices in the array at raw_bufs.
-    states: Vec<BufState>,
-    // Original capacity of raw_bufs as a Vec.
-    orig_cap: usize,
-    // Table of head indices of the free buffer lists in each size bucket.
-    free_buf_head_by_cap: HashMap<usize, u16>,
-}
-
-// State information of a buffer in the registry,
-enum BufState {
-    // The buffer is not in use.
-    Free {
-        // This field records the length of the initialized part.
-        init_len: usize,
-        // Index of the next buffer of the same capacity in a free buffer list, if any.
-        next: Option<u16>,
-    },
-    // The buffer is checked out.
-    // Its data are logically owned by the FixedBuf handle,
-    // which also keeps track of the length of the initialized part.
-    CheckedOut,
-}
-
-impl Inner {
-    fn new(bufs: impl Iterator<Item = Vec<u8>>) -> Self {
-        let bufs = bufs.take(cmp::min(UIO_MAXIOV as usize, u16::MAX as usize));
-        let (size_hint, _) = bufs.size_hint();
-        let mut iovecs = Vec::with_capacity(size_hint);
-        let mut states = Vec::with_capacity(size_hint);
-        let mut free_buf_head_by_cap = HashMap::new();
-        for (index, mut buf) in bufs.enumerate() {
-            let cap = buf.capacity();
-
-            // Link the buffer as the head of the free list for its capacity.
-            // This constructs the free buffer list to be initially retrieved
-            // back to front, which should be of no difference to the user.
-            let next = free_buf_head_by_cap.insert(cap, index as u16);
-
-            iovecs.push(iovec {
-                iov_base: buf.as_mut_ptr() as *mut _,
-                iov_len: cap,
-            });
-            states.push(BufState::Free {
-                init_len: buf.len(),
-                next,
-            });
-            mem::forget(buf);
-        }
-        debug_assert_eq!(iovecs.len(), states.len());
-
-        // Safety: Vec::as_mut_ptr never returns null
-        let raw_bufs = unsafe { ptr::NonNull::new_unchecked(iovecs.as_mut_ptr()) };
-        let orig_cap = iovecs.capacity();
-        mem::forget(iovecs);
-        Inner {
-            raw_bufs,
-            states,
-            orig_cap,
-            free_buf_head_by_cap,
-        }
-    }
-
-    // If the free buffer list for this capacity is not empty, checks out the first buffer
-    // from the list and returns its data. Otherwise, returns None.
-    fn try_next(&mut self, cap: usize) -> Option<CheckedOutBuf> {
-        let free_head = self.free_buf_head_by_cap.get_mut(&cap)?;
-        let index = *free_head as usize;
-        let state = &mut self.states[index];
-
-        let (init_len, next) = match *state {
-            BufState::Free { init_len, next } => {
-                *state = BufState::CheckedOut;
-                (init_len, next)
-            }
-            BufState::CheckedOut => panic!("buffer is checked out"),
-        };
-
-        // Update the head of the free list for this capacity.
-        match next {
-            Some(i) => {
-                *free_head = i;
-            }
-            None => {
-                self.free_buf_head_by_cap.remove(&cap);
-            }
-        }
-
-        // Safety: the allocated array under the pointer is valid
-        // for the lifetime of self, a free buffer index is inside the array,
-        // as also asserted by the indexing operation on the states array
-        // that has the same length.
-        let iovec = unsafe { self.raw_bufs.as_ptr().add(index).read() };
-        debug_assert_eq!(iovec.iov_len, cap);
-        Some(CheckedOutBuf {
-            iovec,
-            init_len,
-            index: index as u16,
-        })
-    }
-
-    fn check_in_internal(&mut self, index: u16, init_len: usize) {
-        let cap = self.iovecs()[index as usize].iov_len;
-        let state = &mut self.states[index as usize];
-        debug_assert!(
-            matches!(state, BufState::CheckedOut),
-            "the buffer must be checked out"
-        );
-
-        // Link the buffer as the new head of the free list for its capacity.
-        // Recently checked in buffers will be first to be reused,
-        // improving cache locality.
-        let next = self.free_buf_head_by_cap.insert(cap, index);
-
-        *state = BufState::Free { init_len, next };
-    }
-}
-
-impl FixedBuffers for Inner {
-    fn iovecs(&self) -> &[iovec] {
-        // Safety: the raw_bufs pointer is valid for the lifetime of self,
-        // the length of the states array is also the length of buffers array
-        // by construction.
-        unsafe { slice::from_raw_parts(self.raw_bufs.as_ptr(), self.states.len()) }
-    }
-
-    unsafe fn check_in(&mut self, index: u16, init_len: usize) {
-        self.check_in_internal(index, init_len)
-    }
-}
-
-impl Drop for Inner {
-    fn drop(&mut self) {
-        let iovecs = unsafe {
-            Vec::from_raw_parts(self.raw_bufs.as_ptr(), self.states.len(), self.orig_cap)
-        };
-        for (i, iovec) in iovecs.iter().enumerate() {
-            match self.states[i] {
-                BufState::Free { init_len, next: _ } => {
-                    let ptr = iovec.iov_base as *mut u8;
-                    let cap = iovec.iov_len;
-                    let v = unsafe { Vec::from_raw_parts(ptr, init_len, cap) };
-                    mem::drop(v);
-                }
-                BufState::CheckedOut => unreachable!("all buffers must be checked in"),
-            }
-        }
     }
 }

--- a/src/buf/fixed/registry.rs
+++ b/src/buf/fixed/registry.rs
@@ -1,16 +1,11 @@
-use super::handle::CheckedOutBuf;
-use super::{FixedBuf, FixedBuffers};
+use super::plumbing;
+use super::FixedBuf;
 
 use crate::runtime::driver::WeakHandle;
 use crate::runtime::CONTEXT;
-use libc::{iovec, UIO_MAXIOV};
 use std::cell::RefCell;
-use std::cmp;
 use std::io;
-use std::mem;
-use std::ptr;
 use std::rc::Rc;
-use std::slice;
 
 /// An indexed collection of I/O buffers pre-registered with the kernel.
 ///
@@ -36,7 +31,7 @@ use std::slice;
 /// [`Runtime`]: crate::Runtime
 #[derive(Clone)]
 pub struct FixedBufRegistry {
-    inner: Rc<RefCell<Inner>>,
+    inner: Rc<RefCell<plumbing::Registry>>,
     driver: WeakHandle,
 }
 
@@ -105,7 +100,7 @@ impl FixedBufRegistry {
     /// ```
     pub fn new(bufs: impl IntoIterator<Item = Vec<u8>>) -> Self {
         FixedBufRegistry {
-            inner: Rc::new(RefCell::new(Inner::new(bufs.into_iter()))),
+            inner: Rc::new(RefCell::new(plumbing::Registry::new(bufs.into_iter()))),
             driver: CONTEXT.with(|x| {
                 x.handle()
                     .as_ref()
@@ -175,130 +170,8 @@ impl FixedBufRegistry {
         inner.check_out(index).map(|data| {
             let registry = Rc::clone(&self.inner);
             // Safety: the validity of buffer data is ensured by
-            // Inner::check_out
+            // plumbing::Registry::check_out
             unsafe { FixedBuf::new(registry, data) }
         })
-    }
-}
-
-// Internal state shared by FixedBufRegistry and FixedBuf handles.
-struct Inner {
-    // Pointer to an allocated array of iovec records referencing
-    // the allocated buffers. The number of initialized records is the
-    // same as the length of the states array.
-    raw_bufs: ptr::NonNull<iovec>,
-    // State information on the buffers. Indices in this array correspond to
-    // the indices in the array at raw_bufs.
-    states: Vec<BufState>,
-    // Original capacity of raw_bufs as a Vec.
-    orig_cap: usize,
-}
-
-// State information of a buffer in the registry,
-enum BufState {
-    // The buffer is not in use.
-    // The field records the length of the initialized part.
-    Free { init_len: usize },
-    // The buffer is checked out.
-    // Its data are logically owned by the FixedBuf handle,
-    // which also keeps track of the length of the initialized part.
-    CheckedOut,
-}
-
-impl Inner {
-    fn new(bufs: impl Iterator<Item = Vec<u8>>) -> Self {
-        let bufs = bufs.take(cmp::min(UIO_MAXIOV as usize, u16::MAX as usize));
-        let (size_hint, _) = bufs.size_hint();
-        let mut iovecs = Vec::with_capacity(size_hint);
-        let mut states = Vec::with_capacity(size_hint);
-        for mut buf in bufs {
-            iovecs.push(iovec {
-                iov_base: buf.as_mut_ptr() as *mut _,
-                iov_len: buf.capacity(),
-            });
-            states.push(BufState::Free {
-                init_len: buf.len(),
-            });
-            mem::forget(buf);
-        }
-        debug_assert_eq!(iovecs.len(), states.len());
-
-        // Safety: Vec::as_mut_ptr never returns null
-        let raw_bufs = unsafe { ptr::NonNull::new_unchecked(iovecs.as_mut_ptr()) };
-        let orig_cap = iovecs.capacity();
-        mem::forget(iovecs);
-        Inner {
-            raw_bufs,
-            states,
-            orig_cap,
-        }
-    }
-
-    // If the indexed buffer is free, changes its state to checked out
-    // and returns its data.
-    // If the buffer is already checked out, returns None.
-    fn check_out(&mut self, index: usize) -> Option<CheckedOutBuf> {
-        let state = self.states.get_mut(index)?;
-        let BufState::Free { init_len } = *state else {
-            return None
-        };
-
-        *state = BufState::CheckedOut;
-
-        // Safety: the allocated array under the pointer is valid
-        // for the lifetime of self, the index is inside the array
-        // as checked by Vec::get_mut above, called on the array of
-        // states that has the same length.
-        let iovec = unsafe { self.raw_bufs.as_ptr().add(index).read() };
-        debug_assert!(index <= u16::MAX as usize);
-        Some(CheckedOutBuf {
-            iovec,
-            init_len,
-            index: index as u16,
-        })
-    }
-
-    fn check_in_internal(&mut self, index: u16, init_len: usize) {
-        let state = self
-            .states
-            .get_mut(index as usize)
-            .expect("invalid buffer index");
-        debug_assert!(
-            matches!(state, BufState::CheckedOut),
-            "the buffer must be checked out"
-        );
-        *state = BufState::Free { init_len };
-    }
-}
-
-impl FixedBuffers for Inner {
-    fn iovecs(&self) -> &[iovec] {
-        // Safety: the raw_bufs pointer is valid for the lifetime of self,
-        // the length of the states array is also the length of buffers array
-        // by construction.
-        unsafe { slice::from_raw_parts(self.raw_bufs.as_ptr(), self.states.len()) }
-    }
-
-    unsafe fn check_in(&mut self, index: u16, init_len: usize) {
-        self.check_in_internal(index, init_len)
-    }
-}
-
-impl Drop for Inner {
-    fn drop(&mut self) {
-        let iovecs = unsafe {
-            Vec::from_raw_parts(self.raw_bufs.as_ptr(), self.states.len(), self.orig_cap)
-        };
-        for (i, iovec) in iovecs.iter().enumerate() {
-            match self.states[i] {
-                BufState::Free { init_len } => {
-                    let ptr = iovec.iov_base as *mut u8;
-                    let cap = iovec.iov_len;
-                    let v = unsafe { Vec::from_raw_parts(ptr, init_len, cap) };
-                    mem::drop(v);
-                }
-                BufState::CheckedOut => unreachable!("all buffers must be checked in"),
-            }
-        }
     }
 }


### PR DESCRIPTION
Add an async API to get buffers out of `FixedBufPool`. This is another way in which `FixedBufPool` will be more useful than `FixedBufRegistry`.

Also reorganize the shared data structures of `FixedBufPool` and `FixedBufRegistry` into separate modules for better readability and future code reuse.