### PR TITLE
Implemented a `test` attribute macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ io-uring support for the Tokio asynchronous runtime.
 categories = ["asynchronous", "network-programming"]
 keywords = ["async", "fs", "io-uring"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
+macros = ["tokio-uring-macros"]
+full = ["macros"]
 
 [dependencies]
 tokio = { version = "1.2", features = ["net", "rt"] }
@@ -23,6 +26,8 @@ libc = "0.2.80"
 io-uring = { version = "0.5.9", features = ["unstable"] }
 socket2 = { version = "0.4.4", features = ["all"] }
 bytes = { version = "1.0", optional = true }
+
+tokio-uring-macros = { version = "0.1.0", path = "./tokio-uring-macros", optional = true }
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,3 +284,7 @@ pub async fn no_op() -> std::io::Result<()> {
     let op = Op::<io::NoOp>::no_op().unwrap();
     op.await
 }
+
+#[cfg(feature = "macros")]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+pub use tokio_uring_macros::test;

--- a/tokio-uring-macros/Cargo.toml
+++ b/tokio-uring-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tokio-uring-macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.49"
+quote = "1.0.23"
+syn = { version = "1.0.107", features = ["full"] }

--- a/tokio-uring-macros/src/lib.rs
+++ b/tokio-uring-macros/src/lib.rs
@@ -1,0 +1,41 @@
+#[proc_macro_attribute]
+pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
+    expand_test(args, item.clone()).unwrap_or_else(|err| token_stream_with_error(item, err))
+}
+
+fn expand_test(args: TokenStream, item: TokenStream) -> Result<TokenStream, syn::Error> {
+    let mut input: syn::ItemFn = syn::parse(item)?;
+    if let Some(attr) = input.attrs.iter().find(|attr| attr.path.is_ident("test")) {
+        let msg = "second test attribute is supplied";
+        return Err(syn::Error::new_spanned(attr, msg));
+    }
+    if !args.is_empty() {
+        let msg = "Unknown attribute inside the macro";
+        return Err(syn::Error::new_spanned(args, msg));
+    }
+    if input.sig.asyncness.is_none() {
+        let msg = "the `async` keyword is missing from the function declaration";
+        return Err(syn::Error::new_spanned(input.sig.fn_token, msg));
+    }
+
+    let body = &input.block;
+    let brace_token = input.block.brace_token;
+    let body = quote! {
+        let body = async #body;
+        ::tokio_uring::start(body)
+    };
+    input.block = syn::parse2(body).expect("Parsing failure");
+    input.block.brace_token = brace_token;
+
+    let result = quote! {
+        #[::core::prelude::v1::test]
+        #input
+    };
+
+    Ok(result.into())
+}
+
+fn token_stream_with_error(mut tokens: TokenStream, error: syn::Error) -> TokenStream {
+    tokens.extend(TokenStream::from(error.into_compile_error()));
+    tokens
+}


### PR DESCRIPTION
Closes #181 
This implements a naive `test` macro, which simply wraps the body of the function in `::tokio_uring::start`.
Opening as a draft because I'm not sure about the design and whether we'd want to also provide a convenience `main` macro.
The current implementation is heavily inspired by the one found in tokio but severely simplified.