### PR TITLE
Add support for `fallocate` and `statx`

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -772,6 +772,58 @@ impl File {
         Op::datasync(&self.fd)?.await
     }
 
+    /// Manipulate the allocated disk space of the file.
+    ///
+    /// The manipulated range starts at the `offset` and continues for `len` bytes.
+    ///
+    /// The specific manipulation to the allocated disk space are specified by
+    /// the `flags`, to understand what are the possible values here check
+    /// the `fallocate(2)` man page.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_uring::fs::File;
+    ///
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     tokio_uring::start(async {
+    ///         let f = File::create("foo.txt").await?;
+    ///
+    ///         // Allocate a 1024 byte file setting all the bytes to zero
+    ///         f.fallocate(0, 1024, libc::FALLOC_FL_ZERO_RANGE).await?;
+    ///
+    ///         // Close the file
+    ///         f.close().await?;
+    ///         Ok(())
+    ///     })
+    /// }
+    pub async fn fallocate(&self, offset: u64, len: u64, flags: i32) -> io::Result<()> {
+        Op::fallocate(&self.fd, offset, len, flags)?.await
+    }
+
+    /// Metadata information about a file.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_uring::fs::File;
+    ///
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     tokio_uring::start(async {
+    ///         let f = File::create("foo.txt").await?;
+    ///
+    ///         // Fetch file metadata
+    ///         let statx = f.statx().await?;
+    ///
+    ///         // Close the file
+    ///         f.close().await?;
+    ///         Ok(())
+    ///     })
+    /// }
+    pub async fn statx(&self) -> io::Result<libc::statx> {
+        Op::statx(&self.fd)?.await
+    }
+
     /// Closes the file.
     ///
     /// The method completes once the close operation has completed,

--- a/src/io/fallocate.rs
+++ b/src/io/fallocate.rs
@@ -1,0 +1,44 @@
+use std::io;
+
+use io_uring::{opcode, types};
+
+use crate::{
+    io::SharedFd,
+    runtime::{
+        driver::op::{Completable, CqeResult, Op},
+        CONTEXT,
+    },
+};
+
+pub(crate) struct Fallocate {
+    fd: SharedFd,
+}
+
+impl Op<Fallocate> {
+    pub(crate) fn fallocate(
+        fd: &SharedFd,
+        offset: u64,
+        len: u64,
+        flags: i32,
+    ) -> io::Result<Op<Fallocate>> {
+        CONTEXT.with(|x| {
+            x.handle().expect("not in a runtime context").submit_op(
+                Fallocate { fd: fd.clone() },
+                |fallocate| {
+                    opcode::Fallocate64::new(types::Fd(fallocate.fd.raw_fd()), len as _)
+                        .offset64(offset as _)
+                        .mode(flags)
+                        .build()
+                },
+            )
+        })
+    }
+}
+
+impl Completable for Fallocate {
+    type Output = io::Result<()>;
+
+    fn complete(self, cqe: CqeResult) -> Self::Output {
+        cqe.result.map(|_| ())
+    }
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -5,6 +5,8 @@ pub(crate) use close::Close;
 
 mod connect;
 
+mod fallocate;
+
 mod fsync;
 
 mod mkdir_at;
@@ -33,6 +35,8 @@ pub(crate) use shared_fd::SharedFd;
 
 mod socket;
 pub(crate) use socket::Socket;
+
+mod statx;
 
 mod unlink_at;
 

--- a/src/io/statx.rs
+++ b/src/io/statx.rs
@@ -21,7 +21,7 @@ impl Op<Statx> {
             x.handle().expect("not in a runtime context").submit_op(
                 Statx {
                     fd: fd.clone(),
-                    statx: unsafe { Box::new(std::mem::zeroed()) },
+                    statx: Box::new(unsafe { std::mem::zeroed() }),
                 },
                 |statx| {
                     opcode::Statx::new(

--- a/src/io/statx.rs
+++ b/src/io/statx.rs
@@ -1,0 +1,48 @@
+use std::{ffi::CStr, io};
+
+use io_uring::{opcode, types};
+
+use crate::runtime::{
+    driver::op::{Completable, CqeResult, Op},
+    CONTEXT,
+};
+
+use super::SharedFd;
+
+pub(crate) struct Statx {
+    fd: SharedFd,
+    statx: Box<libc::statx>,
+}
+
+impl Op<Statx> {
+    pub(crate) fn statx(fd: &SharedFd) -> io::Result<Op<Statx>> {
+        CONTEXT.with(|x| {
+            let empty_path = CStr::from_bytes_with_nul(b"\0").unwrap();
+            x.handle().expect("not in a runtime context").submit_op(
+                Statx {
+                    fd: fd.clone(),
+                    statx: unsafe { Box::new(std::mem::zeroed()) },
+                },
+                |statx| {
+                    opcode::Statx::new(
+                        types::Fd(statx.fd.raw_fd()),
+                        empty_path.as_ptr(),
+                        &mut *statx.statx as *mut libc::statx as *mut types::statx,
+                    )
+                    .flags(libc::AT_EMPTY_PATH)
+                    .mask(libc::STATX_ALL)
+                    .build()
+                },
+            )
+        })
+    }
+}
+
+impl Completable for Statx {
+    type Output = io::Result<libc::statx>;
+
+    fn complete(self, cqe: CqeResult) -> Self::Output {
+        cqe.result?;
+        Ok(*self.statx)
+    }
+}

--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -3,6 +3,8 @@ use std::{
     os::unix::io::{AsRawFd, FromRawFd, RawFd},
 };
 
+use libc;
+
 use tempfile::NamedTempFile;
 
 use tokio_uring::buf::fixed::FixedBufRegistry;
@@ -278,6 +280,38 @@ fn write_fixed() {
 
         let file = std::fs::read(tempfile.path()).unwrap();
         assert_eq!(file, HELLO);
+    });
+}
+
+#[test]
+fn basic_fallocate() {
+    tokio_uring::start(async {
+        let tempfile = tempfile();
+
+        let file = File::create(tempfile.path()).await.unwrap();
+
+        file.fallocate(0, 1024, libc::FALLOC_FL_ZERO_RANGE)
+            .await
+            .unwrap();
+        file.sync_all().await.unwrap();
+
+        let statx = file.statx().await.unwrap();
+        let size = statx.stx_size;
+        assert_eq!(size, 1024);
+
+        // using the FALLOC_FL_KEEP_SIZE flag causes the file metadata to reflect the previous size
+        file.fallocate(
+            0,
+            2048,
+            libc::FALLOC_FL_ZERO_RANGE | libc::FALLOC_FL_KEEP_SIZE,
+        )
+        .await
+        .unwrap();
+        file.sync_all().await.unwrap();
+
+        let statx = file.statx().await.unwrap();
+        let size = statx.stx_size;
+        assert_eq!(size, 1024);
     });
 }
 


### PR DESCRIPTION
This PR adds support for both the `IORING_OP_FALLOCATE` and the `IORING_OP_STATX` opcodes, and extends `File` to expose `fallocate()` and `statx()` methods. 

A basic test which uses both `fallocate` and `statx` is included as well.