### PR TITLE
API: Fix unintuitive / broken `set_init()` behaviour

### DIFF
--- a/src/buf/fixed/handle.rs
+++ b/src/buf/fixed/handle.rs
@@ -95,9 +95,7 @@ unsafe impl IoBufMut for FixedBuf {
     }
 
     unsafe fn set_init(&mut self, pos: usize) {
-        if self.buf.len() < pos {
-            self.buf.set_len(pos)
-        }
+        self.buf.set_init(pos)
     }
 }
 

--- a/src/buf/io_buf_mut.rs
+++ b/src/buf/io_buf_mut.rs
@@ -23,14 +23,12 @@ pub unsafe trait IoBufMut: IoBuf {
 
     /// Updates the number of initialized bytes.
     ///
-    /// If the specified `pos` is greater than the value returned by
-    /// [`IoBuf::bytes_init`], it becomes the new water mark as returned by
-    /// `IoBuf::bytes_init`.
-    ///
     /// # Safety
     ///
     /// The caller must ensure that all bytes starting at `stable_mut_ptr()` up
     /// to `pos` are initialized and owned by the buffer.
+    ///
+    /// The number of bytes must be less than or equal to bytes_total()
     unsafe fn set_init(&mut self, pos: usize);
 }
 
@@ -40,9 +38,7 @@ unsafe impl IoBufMut for Vec<u8> {
     }
 
     unsafe fn set_init(&mut self, init_len: usize) {
-        if self.len() < init_len {
-            self.set_len(init_len);
-        }
+        self.set_len(init_len);
     }
 }
 
@@ -53,8 +49,6 @@ unsafe impl IoBufMut for bytes::BytesMut {
     }
 
     unsafe fn set_init(&mut self, init_len: usize) {
-        if self.len() < init_len {
-            self.set_len(init_len);
-        }
+        self.set_len(init_len);
     }
 }

--- a/tests/buf.rs
+++ b/tests/buf.rs
@@ -27,11 +27,11 @@ fn test_vec() {
     assert_eq!(v.bytes_init(), 5);
     assert_eq!(v.bytes_total(), v.capacity());
 
-    // Assume init does not go backwards
+    // Init may go backwards
     unsafe {
         v.set_init(3);
     }
-    assert_eq!(&v[..], b"hello");
+    assert_eq!(&v[..], b"hel");
 
     // Initializing goes forward
     unsafe {


### PR DESCRIPTION
The original discussion came up here https://github.com/tokio-rs/tokio-uring/pull/213#discussion_r1084501623 I'll rephase my arguments here:

Having `bytes_init()` only ever go up is broken. Consider the following example for copying data from a socket into a file

``` rust
let mut buf = Vec::with_capacity(2048);
loop {
    b = socket.recv(buf).await.1;
    let _ = target.write_at(b,0).await;
}
```

This example is broken,  because the `set_init` function is a one way ratchet, which can never be unset. It is called in `recv`, and all other read-like apis which fill buffers, to set the number of bytes read. However, set_init, in the current implmentation, ignores this value if its less than the previous number of initialised bytes. Unfortunately, large parts of write-like functions in the current API (and me) assume that `bytes_init` is equivalent to _valid bytes of interest_. As it stands `IoBuf` has no concept of length, only of bytes which have historically been valid (historical max len).

It is never possible to call a write-like function with a reused buffer. The IoBuf does not carry information on how many bytes to write.

This PR gets rid of the lifetime initialization counter, and replaces it with a the meaning of _currently initialized bytes_. I.e, after a read, the number of initialized bytes is the number read.

