### PR TITLE
fix: API IO bounds should use BoundedBuf

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -226,7 +226,7 @@ impl File {
     ///     })
     /// }
     /// ```
-    pub async fn readv_at<T: IoBufMut>(
+    pub async fn readv_at<T: BoundedBufMut>(
         &self,
         bufs: Vec<T>,
         pos: u64,
@@ -283,7 +283,7 @@ impl File {
     /// ```
     ///
     /// [`Ok(n)`]: Ok
-    pub async fn writev_at<T: IoBuf>(
+    pub async fn writev_at<T: BoundedBuf>(
         &self,
         buf: Vec<T>,
         pos: u64,
@@ -408,7 +408,7 @@ impl File {
     ///# fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use tokio_uring::fs::File;
     /// use tokio_uring::buf::fixed::FixedBufRegistry;
-    /// use tokio_uring::buf::IoBuf;
+    /// use tokio_uring::buf::BoundedBuf;
     /// use std::iter;
     ///
     /// tokio_uring::start(async {
@@ -601,7 +601,7 @@ impl File {
     ///# fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use tokio_uring::fs::File;
     /// use tokio_uring::buf::fixed::FixedBufRegistry;
-    /// use tokio_uring::buf::IoBuf;
+    /// use tokio_uring::buf::BoundedBuf;
     ///
     /// tokio_uring::start(async {
     ///     let registry = FixedBufRegistry::new([b"some bytes".to_vec()]);

--- a/src/io/readv.rs
+++ b/src/io/readv.rs
@@ -1,4 +1,4 @@
-use crate::buf::IoBufMut;
+use crate::buf::BoundedBufMut;
 use crate::BufResult;
 
 use crate::io::SharedFd;
@@ -19,7 +19,7 @@ pub(crate) struct Readv<T> {
     iovs: Vec<iovec>,
 }
 
-impl<T: IoBufMut> Op<Readv<T>> {
+impl<T: BoundedBufMut> Op<Readv<T>> {
     pub(crate) fn readv_at(
         fd: &SharedFd,
         mut bufs: Vec<T>,
@@ -31,7 +31,7 @@ impl<T: IoBufMut> Op<Readv<T>> {
         let iovs: Vec<iovec> = bufs
             .iter_mut()
             .map(|b| iovec {
-                // Safety guaranteed by `IoBufMut`.
+                // Safety guaranteed by `BoundedBufMut`.
                 iov_base: unsafe { b.stable_mut_ptr().add(b.bytes_init()) as *mut libc::c_void },
                 iov_len: b.bytes_total() - b.bytes_init(),
             })
@@ -60,7 +60,7 @@ impl<T: IoBufMut> Op<Readv<T>> {
 
 impl<T> Completable for Readv<T>
 where
-    T: IoBufMut,
+    T: BoundedBufMut,
 {
     type Output = BufResult<usize, Vec<T>>;
 

--- a/src/io/sendmsg_zc.rs
+++ b/src/io/sendmsg_zc.rs
@@ -1,4 +1,4 @@
-use crate::buf::IoBuf;
+use crate::buf::BoundedBuf;
 use crate::io::SharedFd;
 use crate::runtime::driver::op::{Completable, CqeResult, MultiCQEFuture, Op, Updateable};
 use crate::runtime::CONTEXT;
@@ -21,7 +21,7 @@ pub(crate) struct SendMsgZc<T, U> {
     bytes: usize,
 }
 
-impl<T: IoBuf, U: IoBuf> Op<SendMsgZc<T, U>, MultiCQEFuture> {
+impl<T: BoundedBuf, U: BoundedBuf> Op<SendMsgZc<T, U>, MultiCQEFuture> {
     pub(crate) fn sendmsg_zc(
         fd: &SharedFd,
         io_bufs: Vec<T>,

--- a/src/io/socket.rs
+++ b/src/io/socket.rs
@@ -128,7 +128,7 @@ impl Socket {
         (Ok(()), buf.into_inner())
     }
 
-    pub async fn writev<T: IoBuf>(&self, buf: Vec<T>) -> crate::BufResult<usize, Vec<T>> {
+    pub async fn writev<T: BoundedBuf>(&self, buf: Vec<T>) -> crate::BufResult<usize, Vec<T>> {
         let op = Op::writev_at(&self.fd, buf, 0).unwrap();
         op.await
     }
@@ -147,7 +147,7 @@ impl Socket {
         op.await
     }
 
-    pub(crate) async fn sendmsg_zc<T: IoBuf, U: IoBuf>(
+    pub(crate) async fn sendmsg_zc<T: BoundedBuf, U: BoundedBuf>(
         &self,
         io_slices: Vec<T>,
         socket_addr: SocketAddr,

--- a/src/io/writev.rs
+++ b/src/io/writev.rs
@@ -1,6 +1,6 @@
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
-use crate::{buf::IoBuf, io::SharedFd, BufResult};
+use crate::{buf::BoundedBuf, io::SharedFd, BufResult};
 use libc::iovec;
 use std::io;
 
@@ -16,7 +16,7 @@ pub(crate) struct Writev<T> {
     iovs: Vec<iovec>,
 }
 
-impl<T: IoBuf> Op<Writev<T>> {
+impl<T: BoundedBuf> Op<Writev<T>> {
     pub(crate) fn writev_at(
         fd: &SharedFd,
         mut bufs: Vec<T>,
@@ -56,7 +56,7 @@ impl<T: IoBuf> Op<Writev<T>> {
 
 impl<T> Completable for Writev<T>
 where
-    T: IoBuf,
+    T: BoundedBuf,
 {
     type Output = BufResult<usize, Vec<T>>;
 

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     buf::fixed::FixedBuf,
-    buf::{BoundedBuf, BoundedBufMut, IoBuf},
+    buf::{BoundedBuf, BoundedBufMut},
     io::{SharedFd, Socket},
 };
 
@@ -221,7 +221,7 @@ impl TcpStream {
     /// written to this writer.
     ///
     /// [`Ok(n)`]: Ok
-    pub async fn writev<T: IoBuf>(&self, buf: Vec<T>) -> crate::BufResult<usize, Vec<T>> {
+    pub async fn writev<T: BoundedBuf>(&self, buf: Vec<T>) -> crate::BufResult<usize, Vec<T>> {
         self.inner.writev(buf).await
     }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,6 +1,6 @@
 use crate::{
     buf::fixed::FixedBuf,
-    buf::{BoundedBuf, BoundedBufMut, IoBuf},
+    buf::{BoundedBuf, BoundedBufMut},
     io::{SharedFd, Socket},
 };
 use socket2::SockAddr;
@@ -243,7 +243,7 @@ impl UdpSocket {
     /// > at writes over around 10 KB.
     ///
     /// Note: Using fixed buffers [#54](https://github.com/tokio-rs/tokio-uring/pull/54), avoids the page-pinning overhead
-    pub async fn sendmsg_zc<T: IoBuf, U: IoBuf>(
+    pub async fn sendmsg_zc<T: BoundedBuf, U: BoundedBuf>(
         &self,
         io_slices: Vec<T>,
         socket_addr: SocketAddr,

--- a/src/net/unix/stream.rs
+++ b/src/net/unix/stream.rs
@@ -1,6 +1,6 @@
 use crate::{
     buf::fixed::FixedBuf,
-    buf::{BoundedBuf, BoundedBufMut, IoBuf},
+    buf::{BoundedBuf, BoundedBufMut},
     io::{SharedFd, Socket},
 };
 use socket2::SockAddr;
@@ -181,7 +181,7 @@ impl UnixStream {
     /// written to this writer.
     ///
     /// [`Ok(n)`]: Ok
-    pub async fn writev<T: IoBuf>(&self, buf: Vec<T>) -> crate::BufResult<usize, Vec<T>> {
+    pub async fn writev<T: BoundedBuf>(&self, buf: Vec<T>) -> crate::BufResult<usize, Vec<T>> {
         self.inner.writev(buf).await
     }
 


### PR DESCRIPTION
Some of the more recently introduced API IO calls used the original IoBuf and IoBufMut traits without realizing the more general trait is BoundedBuf and BoundedBufMut.

Interesting that callers to the library might not notice until they try to pass a slice of a buffer to one of the IO calls.