### PR TITLE
[buf/fixed] FixedBufAllocator implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ libc = "0.2.80"
 io-uring = { version = "0.5.12", features = ["unstable"] }
 socket2 = { version = "0.4.4", features = ["all"] }
 bytes = { version = "1.0", optional = true }
+buddy-alloc = "0.4.1"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/buf/fixed/allocator.rs
+++ b/src/buf/fixed/allocator.rs
@@ -1,0 +1,218 @@
+use std::{alloc::Layout, cell::RefCell, io, ptr::NonNull, rc::Rc};
+
+use buddy_alloc::{buddy_alloc::BuddyAlloc, BuddyAllocParam};
+use libc::iovec;
+
+use crate::runtime::CONTEXT;
+
+use super::{buffers::AllocatableBuffers, handle::AllocatedBuf, FixedBuf, FixedBuffers};
+
+/// An allocateable I/O buffer heap pre-registered with the kernel.
+///
+/// `FixedBufAllocator` allows the application to manage a buffer heap
+/// allocated in memory, that can be registered in the current `tokio-uring`
+/// context using the [`register`] method. Unlike [`FixedBufRegistry`],
+/// individual buffers are not retrieved by index; instead, an available
+/// buffer matching a specified capacity can be retrieved with the [`allocate_fixed`]
+/// method. This allows some flexibility in managing buffers without pre-selecting
+/// the desired capacities required, at the expense of some bookeeping overhead.
+///
+/// A `FixedBufAllocator` value is a lightweight handle for a buffer heap.
+/// Cloning of a `FixedBufAllocator` creates a new reference to
+/// the same buffer heap.
+///
+/// The buffers of the collection are not deallocated until:
+/// - all `FixedBufAllocator` references to the heap have been dropped;
+/// - all [`FixedBuf`] handles to individual buffers in the heap have
+///   been dropped, including the buffer handles owned by any I/O operations
+///   in flight;
+/// - The `tokio-uring` [`Runtime`] the buffers are registered with
+///   has been dropped.
+///
+/// [`register`]: Self::register
+/// [`allocate_fixed`]: Self::allocate_fixed
+/// [`Runtime`]: crate::Runtime
+#[derive(Clone)]
+pub struct FixedBufAllocator {
+    inner: Rc<RefCell<Inner>>,
+}
+
+impl FixedBufAllocator {
+    /// Creates a new buffer heap of the requested size.
+    ///
+    /// Currently this is limited to the size of a single iovec that can
+    /// be passed to `io_uring` which limits us to 1GiB of heap per allocator.
+    ///
+    /// There is a hard limit to the heap of [`RLIMIT_MEMLOCK`], of course
+    /// this is not a per-runtime setting, so the practical limit will possibly be
+    /// lower.
+    ///
+    /// [`RLIMIT_MEMLOCK`]: nix::sys::resource::Resource::RLIMIT_MEMLOCK
+    pub fn new(size: usize) -> io::Result<Self> {
+        // the buddy allocator will use some of the space in the buffer for metadata
+        // and so the layout.size() will be greater than allocator.available_bytes()
+        let layout = Layout::from_size_align(size, 4096)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+        let heap = unsafe {
+            let data = std::alloc::alloc(layout) as *mut u8;
+            NonNull::new(data).unwrap()
+        };
+        Ok(FixedBufAllocator {
+            inner: Rc::new(RefCell::new(Inner::with_heap(heap, layout))),
+        })
+    }
+
+    /// Available bytes in the allocator
+    pub fn available_bytes(&self) -> usize {
+        self.inner.borrow().allocator.available_bytes()
+    }
+
+    /// Registers the buffer heap with the kernel.
+    ///
+    /// This method must be called in the context of a `tokio-uring` runtime.
+    /// The registration persists for the lifetime of the runtime, unless
+    /// revoked by the [`unregister`] method. Dropping the
+    /// `FixedBufAllocator` instance this method has been called on does not revoke
+    /// the registration or deallocate the buffers.
+    ///
+    /// [`unregister`]: Self::unregister
+    ///
+    /// This call can be blocked in the kernel to complete any operations
+    /// in-flight on the same `io-uring` instance. The application is
+    /// recommended to register buffers before starting any I/O operations.
+    ///
+    /// # Errors
+    ///
+    /// If collection of buffers is currently registered in the context
+    /// of the `tokio-uring` runtime this call is made in, the function returns
+    /// an error.
+    pub fn register(&self) -> io::Result<()> {
+        CONTEXT.with(|x| {
+            x.handle()
+                .as_ref()
+                .expect("Not in a runtime context")
+                .register_buffers(Rc::clone(&self.inner) as _)
+        })
+    }
+
+    /// Unregisters this buffer heap.
+    ///
+    /// This method must be called in the context of a `tokio-uring` runtime,
+    /// where the buffers should have been previously registered.
+    ///
+    /// This operation invalidates any `FixedBuf` handles checked out from
+    /// this registry instance. Continued use of such handles in I/O
+    /// operations may result in an error.
+    ///
+    /// # Errors
+    ///
+    /// If another collection of buffers is currently registered in the context
+    /// of the `tokio-uring` runtime this call is made in, the function returns
+    /// an error. Calling `unregister` when no `FixedBufPool` is currently
+    /// registered on this runtime also returns an error.
+    pub fn unregister(&self) -> io::Result<()> {
+        CONTEXT.with(|x| {
+            x.handle()
+                .as_ref()
+                .expect("Not in a runtime context")
+                .unregister_buffers(Rc::clone(&self.inner) as _)
+        })
+    }
+
+    /// Returns a buffer of requested capacity from this allocator
+    /// that is not currently owned by any other [`FixedBuf`] handle.
+    /// If no such free buffer is available, returns `None`.
+    ///
+    /// The buffer is released to be available again once the
+    /// returned `FixedBuf` handle has been dropped. An I/O operation
+    /// using the buffer takes ownership of it and returns it once completed,
+    /// preventing shared use of the buffer while the operation is in flight.
+    ///
+    /// An application should not rely on any particular order
+    /// in which available buffers are retrieved.
+    pub fn allocate_fixed(&self, cap: usize) -> Option<FixedBuf> {
+        let mut inner = self.inner.borrow_mut();
+        inner.allocate_fixed(cap).map(|buf| {
+            let allocator = Rc::clone(&self.inner);
+            // Safety: the validity of buffer data is ensured by
+            // Inner::allocate_fixed
+            unsafe { FixedBuf::new(allocator, buf) }
+        })
+    }
+}
+
+struct Inner {
+    // Pointer to the start of the heap.
+    heap: NonNull<u8>,
+    // Layout of the heap
+    layout: Layout,
+    // Buddy allocator for the heap
+    allocator: BuddyAlloc,
+    // iovec mappted to the heap for registration
+    // for now we are limited to just a single iovec
+    // if it crosses the limit of io_uring that is a registration error
+    iovec: Vec<iovec>,
+}
+
+impl Inner {
+    fn with_heap(heap: NonNull<u8>, layout: Layout) -> Self {
+        let size = layout.size();
+
+        let iovec = vec![iovec {
+            iov_base: heap.as_ptr() as _,
+            iov_len: layout.size(),
+        }];
+
+        Inner {
+            heap,
+            layout,
+            allocator: unsafe {
+                BuddyAlloc::new(BuddyAllocParam::new(
+                    heap.as_ptr() as _,
+                    size,
+                    layout.align(),
+                ))
+            },
+            iovec,
+        }
+    }
+
+    // If there is available space in the heap, return an AllocatedBuf of the requested size,
+    // otherwise return None
+    fn allocate_fixed(&mut self, cap: usize) -> Option<AllocatedBuf> {
+        NonNull::new(self.allocator.malloc(cap)).map(|buf| {
+            let iovec = iovec {
+                iov_base: buf.as_ptr() as _,
+                iov_len: cap,
+            };
+            let init_len = cap;
+            let index = 0; // just one possible registration currently
+            AllocatedBuf {
+                iovec,
+                init_len,
+                index,
+            }
+        })
+    }
+}
+
+impl FixedBuffers for Inner {
+    // Construct the iovec slice on the fly, this only gets called during registration
+    fn iovecs(&self) -> &[iovec] {
+        self.iovec.as_slice().as_ref()
+    }
+}
+
+unsafe impl AllocatableBuffers for Inner {
+    unsafe fn free(&mut self, buf: AllocatedBuf) {
+        self.allocator.free(buf.iovec.iov_base as _)
+    }
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        unsafe {
+            std::alloc::dealloc(self.heap.as_ptr(), self.layout);
+        }
+    }
+}

--- a/src/buf/fixed/allocator.rs
+++ b/src/buf/fixed/allocator.rs
@@ -195,11 +195,11 @@ impl Inner {
 
 impl FixedBuffers for Inner {
     fn iovecs(&self) -> &[iovec] {
-        self.iovec.as_slice().as_ref()
+        self.iovec.as_slice()
     }
 }
 
-unsafe impl AllocatableBuffers for Inner {
+impl AllocatableBuffers for Inner {
     unsafe fn free(&mut self, buf: AllocatedBuf) {
         self.allocator.free(buf.iovec.iov_base as _)
     }

--- a/src/buf/fixed/buffers.rs
+++ b/src/buf/fixed/buffers.rs
@@ -26,5 +26,6 @@ pub(super) unsafe trait AllocatableBuffers: FixedBuffers {
 // Abstracts access of fixed buffers in a buffer allocator.
 pub(crate) trait FixedBuffers {
     // Provides access to the raw buffers as a slice of iovec.
+    // used during registration to hand buffers to the kernel.
     fn iovecs(&self) -> &[iovec];
 }

--- a/src/buf/fixed/buffers.rs
+++ b/src/buf/fixed/buffers.rs
@@ -1,22 +1,30 @@
 use libc::iovec;
 
-// Abstracts management of fixed buffers in a buffer registry.
-pub(crate) trait FixedBuffers {
-    // Provides access to the raw buffers as a slice of iovec.
-    fn iovecs(&self) -> &[iovec];
+use super::handle::AllocatedBuf;
 
+// Abstracts management of fixed buffers in a buffer allocator.
+pub(super) unsafe trait AllocatableBuffers: FixedBuffers {
+    /// Releases the buffer back to its allocator implementation so it can be reused.
+    ///
     /// Sets the indexed buffer's state to free and records the updated length
     /// of its initialized part.
     ///
     /// # Panics
     ///
-    /// The buffer addressed must be in the checked out state,
+    /// The buffer addressed must be in a valid state for the allocator to reclaim
     /// otherwise this function may panic.
     ///
     /// # Safety
     ///
     /// While the implementation of this method typically does not need to
-    /// do anything unsafe, the caller must ensure that the bytes in the buffer
+    /// do anything unsafe, freeing a buffer not provided by this allocator is undefined,
+    /// the caller must ensure that the bytes in the buffer
     /// are initialized up to the specified length.
-    unsafe fn check_in(&mut self, buf_index: u16, init_len: usize);
+    unsafe fn free(&mut self, buf: AllocatedBuf);
+}
+
+// Abstracts access of fixed buffers in a buffer allocator.
+pub(crate) trait FixedBuffers {
+    // Provides access to the raw buffers as a slice of iovec.
+    fn iovecs(&self) -> &[iovec];
 }

--- a/src/buf/fixed/buffers.rs
+++ b/src/buf/fixed/buffers.rs
@@ -3,7 +3,7 @@ use libc::iovec;
 use super::handle::AllocatedBuf;
 
 // Abstracts management of fixed buffers in a buffer allocator.
-pub(super) unsafe trait AllocatableBuffers: FixedBuffers {
+pub(super) trait AllocatableBuffers: FixedBuffers {
     /// Releases the buffer back to its allocator implementation so it can be reused.
     ///
     /// Sets the indexed buffer's state to free and records the updated length

--- a/src/buf/fixed/mod.rs
+++ b/src/buf/fixed/mod.rs
@@ -5,8 +5,9 @@
 //! [`File::write_fixed_at`][wfa] make use of buffers pre-mapped by
 //! the kernel to reduce per-I/O overhead.
 //!
-//! Two kinds of buffer collections are provided: [`FixedBufRegistry`] and
-//! [`FixedBufPool`], realizing two different patterns of buffer management.
+//! Three kinds of buffer collections are provided: [`FixedBufRegistry`],
+//! [`FixedBufPool`] and [`FixedBufAllocator`], realizing two different patterns of buffer management.
+//!
 //! The `register` method on either of these types is used to register a
 //! collection of buffers with the kernel. It must be called before any of
 //! the [`FixedBuf`] handles to the collection's buffers can be used with
@@ -14,6 +15,9 @@
 //!
 //! [rfa]: crate::fs::File::read_fixed_at
 //! [wfa]: crate::fs::File::write_fixed_at
+
+mod allocator;
+pub use allocator::FixedBufAllocator;
 
 mod handle;
 pub use handle::FixedBuf;

--- a/src/buf/fixed/mod.rs
+++ b/src/buf/fixed/mod.rs
@@ -6,7 +6,7 @@
 //! the kernel to reduce per-I/O overhead.
 //!
 //! Three kinds of buffer collections are provided: [`FixedBufRegistry`],
-//! [`FixedBufPool`] and [`FixedBufAllocator`], realizing two different patterns of buffer management.
+//! [`FixedBufPool`] and [`FixedBufAllocator`], realizing different patterns of buffer management.
 //!
 //! The `register` method on either of these types is used to register a
 //! collection of buffers with the kernel. It must be called before any of

--- a/src/buf/fixed/pool.rs
+++ b/src/buf/fixed/pool.rs
@@ -372,7 +372,7 @@ impl<T: IoBufMut> FixedBuffers for Inner<T> {
     }
 }
 
-unsafe impl<T: IoBufMut> AllocatableBuffers for Inner<T> {
+impl<T: IoBufMut> AllocatableBuffers for Inner<T> {
     unsafe fn free(&mut self, buf: AllocatedBuf) {
         self.check_in_internal(buf.index, buf.init_len)
     }

--- a/src/buf/fixed/registry.rs
+++ b/src/buf/fixed/registry.rs
@@ -287,7 +287,7 @@ impl<T: IoBufMut> FixedBuffers for Inner<T> {
     }
 }
 
-unsafe impl<T: IoBufMut> AllocatableBuffers for Inner<T> {
+impl<T: IoBufMut> AllocatableBuffers for Inner<T> {
     unsafe fn free(&mut self, buf: AllocatedBuf) {
         self.check_in_internal(buf.index, buf.init_len)
     }


### PR DESCRIPTION
This PR introduces the concept of a `FixedBufAllocator`.

I wanted to provide a third option for obtaining `FixedBuf` from the `tokio-uring` runtime. While both the `FixedBufRegistry` and the `FixedBufPool` are excellent choices when it is known precisely what sized buffers you will need upfront. In times when that isn't well known, falling back on dynamic memory management is a good option.

This PR makes some modifications to the internals of the `FixedBuf` so that the drop behavior makes sense wether we need to "check-in" the buffer or "free" it.

There is also a test case included to exercise the allocator.

One limitation of the allocator approach at the moment is we cannot grow a heap beyond a single registered `iovec`. There may be a way around this limitation, if we can ensure allocations never cross certain byte addresses (if thats possible we can just map multiple `iovec` to contiguous ranges on the heap), but for now heaps are limited to ~1GiB (the allocator itself consumes a bit of the heap for alignment and bookkeeping).