### PR TITLE
fix: fs::create_dir mode

### DIFF
--- a/src/io/mkdir_at.rs
+++ b/src/io/mkdir_at.rs
@@ -26,7 +26,9 @@ impl Op<Mkdir> {
                 .submit_op(Mkdir { _path }, |mkdir| {
                     let p_ref = mkdir._path.as_c_str().as_ptr();
 
-                    opcode::MkDirAt::new(types::Fd(libc::AT_FDCWD), p_ref).build()
+                    opcode::MkDirAt::new(types::Fd(libc::AT_FDCWD), p_ref)
+                        .mode(0o777)
+                        .build()
                 })
         })
     }


### PR DESCRIPTION
The io-uring MkDirAt defaults to creating directories with mode 0.

Fix our fs::create_dir, which calls that, to pass a mode of 0o777.

A DirBuilder that allows setting the mode is coming shortly.