### PR TITLE
statx builder

### DIFF
--- a/src/fs/create_dir_all.rs
+++ b/src/fs/create_dir_all.rs
@@ -124,10 +124,6 @@ impl DirBuilder {
     // recursion when only the first level of the directory needs to be built. For now, this serves
     // its purpose.
 
-    // TODO this is a bit expensive for the case of creating a directory that already exists
-    // because after the call to mkdir fails, it will make three more async calls to determine the
-    // path already exists and is a directory.
-
     fn recurse_create_dir_all<'a>(&'a self, path: &'a Path) -> LocalBoxFuture<io::Result<()>> {
         Box::pin(async move {
             if path == Path::new("") {
@@ -194,20 +190,14 @@ mod fs_imp {
 
 // Returns true if the path represents a directory.
 //
-// Uses three asynchronous uring calls to determine this.
+// Uses one asynchronous uring call to determine this.
 async fn is_dir<P: AsRef<Path>>(path: P) -> bool {
-    let f = match crate::fs::File::open(path).await {
-        Ok(f) => f,
-        _ => return false,
-    };
-
-    // f is closed asynchronously, regardless of the statx result.
-
-    let b: bool = match f.statx().await {
+    let res = crate::fs::StatxBuilder::new()
+        .mask(libc::STATX_TYPE)
+        .statx_path(path)
+        .await;
+    match res {
         Ok(statx) => (u32::from(statx.stx_mode) & libc::S_IFMT) == libc::S_IFDIR,
-        _ => false,
-    };
-
-    let _ = f.close().await;
-    b
+        Err(_) => false,
+    }
 }

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -55,7 +55,7 @@ use std::path::Path;
 /// ```
 pub struct File {
     /// Open file descriptor
-    fd: SharedFd,
+    pub(crate) fd: SharedFd,
 }
 
 impl File {
@@ -799,29 +799,6 @@ impl File {
     /// }
     pub async fn fallocate(&self, offset: u64, len: u64, flags: i32) -> io::Result<()> {
         Op::fallocate(&self.fd, offset, len, flags)?.await
-    }
-
-    /// Metadata information about a file.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use tokio_uring::fs::File;
-    ///
-    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     tokio_uring::start(async {
-    ///         let f = File::create("foo.txt").await?;
-    ///
-    ///         // Fetch file metadata
-    ///         let statx = f.statx().await?;
-    ///
-    ///         // Close the file
-    ///         f.close().await?;
-    ///         Ok(())
-    ///     })
-    /// }
-    pub async fn statx(&self) -> io::Result<libc::statx> {
-        Op::statx(&self.fd)?.await
     }
 
     /// Closes the file.

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -11,3 +11,5 @@ pub use file::File;
 
 mod open_options;
 pub use open_options::OpenOptions;
+
+mod statx;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -17,3 +17,6 @@ mod open_options;
 pub use open_options::OpenOptions;
 
 mod statx;
+pub use statx::is_dir_regfile;
+pub use statx::statx;
+pub use statx::StatxBuilder;

--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -1,28 +1,303 @@
 use super::File;
 use crate::runtime::driver::op::Op;
 use std::io;
+use std::path::Path;
 
 impl File {
-    /// Metadata information about a file.
+    /// Returns statx(2) metadata for an open file via a uring call.
+    ///
+    /// The libc::statx structure returned is described in the statx(2) man page.
+    ///
+    /// This high level version of the statx function uses `flags` set to libc::AT_EMPTY_PATH and
+    /// `mask` set to libc::STATX_ALL which are described in the same man page.
+    ///
+    /// More specific uring statx(2) calls can be made with the StatxBuilder.
     ///
     /// # Examples
     ///
     /// ```no_run
     /// use tokio_uring::fs::File;
     ///
-    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     tokio_uring::start(async {
-    ///         let f = File::create("foo.txt").await?;
+    /// tokio_uring::start(async {
+    ///     let f = File::create("foo.txt").await.unwrap();
     ///
-    ///         // Fetch file metadata
-    ///         let statx = f.statx().await?;
+    ///     // Fetch file metadata
+    ///     let statx = f.statx().await.unwrap();
     ///
-    ///         // Close the file
-    ///         f.close().await?;
-    ///         Ok(())
-    ///     })
-    /// }
+    ///     // Close the file
+    ///     f.close().await.unwrap();
+    /// })
+    /// ```
     pub async fn statx(&self) -> io::Result<libc::statx> {
-        Op::statx(&self.fd)?.await
+        let flags = libc::AT_EMPTY_PATH;
+        let mask = libc::STATX_ALL;
+        Op::statx(Some(&self.fd), None, flags, mask)?.await
+    }
+
+    /// Returns a builder that can return statx(2) metadata for an open file using the uring
+    /// device.
+    ///
+    /// `flags` and `mask` can be changed from their defaults and a `path` that is absolule or
+    /// relative can also be provided.
+    ///
+    /// `flags` defaults to libc::AT_EMPTY_PATH.
+    ///
+    /// `mask` defaults to libc::STATX_ALL.
+    ///
+    /// Refer to statx(2) for details on the arguments and the returned value.
+    ///
+    /// A little from the man page:
+    ///
+    ///  - statx(2) uses path, dirfd, and flags to identify the target file.
+    ///  - statx(2) uses mask to tell the kernel which fields the caller is interested in.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_uring::fs::File;
+    ///
+    /// tokio_uring::start(async {
+    ///     let f = File::create("foo.txt").await.unwrap();
+    ///
+    ///     // Fetch file metadata
+    ///     let statx = f.statx_builder()
+    ///         .flags(libc::AT_NO_AUTOMOUNT)
+    ///         .statx().await.unwrap();
+    ///
+    ///     // Close the file
+    ///     f.close().await.unwrap();
+    /// })
+    /// ```
+    pub fn statx_builder(&self) -> StatxBuilder {
+        StatxBuilder {
+            file: Some(self),
+            flags: libc::AT_EMPTY_PATH,
+            mask: libc::STATX_ALL,
+        }
+    }
+}
+
+/// Returns statx(2) metadata for a path via a uring call.
+///
+/// The libc::statx structure returned is described in the statx(2) man page.
+///
+/// This high level version of the statx function uses `flags` set to libc::AT_EMPTY_PATH and
+/// `mask` set to libc::STATX_ALL which are described in the same man page.
+///
+/// And this version of the function does not work on an open file descriptor can be more expedient
+/// when an open file descriptor isn't necessary for other reasons anyway.
+///
+/// The path can be absolute or relative. A relative path is interpreted against the current
+/// working direcgtory.
+///
+/// More specific uring statx(2) calls can be made with the StatxBuilder.
+///
+/// # Examples
+///
+/// ```no_run
+/// tokio_uring::start(async {
+///
+///     // Fetch file metadata
+///     let statx = tokio_uring::fs::statx("foo.txt").await.unwrap();
+/// })
+/// ```
+pub async fn statx<P: AsRef<Path>>(path: P) -> io::Result<libc::statx> {
+    StatxBuilder::new().statx_path(path).await
+}
+
+/// A builder used to make a uring statx(2) call.
+///
+/// This builder supports the `flags` and `mask` options and can be finished with a call to
+/// `statx()` or to `statx_path().
+///
+/// See StatxBuilder::new for more details.
+#[derive(Debug)]
+pub struct StatxBuilder<'a> {
+    file: Option<&'a File>,
+    flags: i32,
+    mask: u32,
+}
+
+impl<'a> Default for StatxBuilder<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'a> StatxBuilder<'a> {
+    /// Returns a builder to fully specify the arguments to the uring statx(2) operation.
+    ///
+    /// The libc::statx structure returned in described in the statx(2) man page.
+    ///
+    /// This builder defaults to having no open file descriptor and defaults `flags` to
+    /// libc::AT_EMPTY_PATH and `mask` to libc::STATX_ALL.
+    ///
+    /// Refer to the man page for details about the `flags`, `mask` values and returned structure,
+    /// libc::statx.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// tokio_uring::start(async {
+    ///     let want_mode: u16 = 0o775;
+    ///
+    ///     // Fetch file metadata
+    ///     let statx = tokio_uring::fs::StatxBuilder::new()
+    ///         .mask(libc::STATX_MODE)
+    ///         .statx_path("foo.txt").await.unwrap();
+    ///     let got_mode = statx.stx_mode & 0o7777;
+    ///
+    ///     if want_mode == got_mode {
+    ///         println!("Success: wanted mode {want_mode:#o}, got mode {got_mode:#o}");
+    ///     } else {
+    ///         println!("Fail: wanted mode {want_mode:#o}, got mode {got_mode:#o}");
+    ///     }
+    /// })
+    /// ```
+    #[must_use]
+    pub fn new() -> StatxBuilder<'a> {
+        StatxBuilder {
+            file: None,
+            flags: libc::AT_EMPTY_PATH,
+            mask: libc::STATX_ALL,
+        }
+    }
+
+    /// Sets the `flags` option, replacing the default.
+    ///
+    /// See statx(2) for a full description of `flags`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// tokio_uring::start(async {
+    ///     // Fetch file metadata
+    ///     let statx = tokio_uring::fs::StatxBuilder::new()
+    ///         .flags(libc::AT_NO_AUTOMOUNT)
+    ///         .statx_path("foo.txt").await.unwrap();
+    /// })
+    /// ```
+    #[must_use]
+    pub fn flags(&mut self, flags: i32) -> &mut Self {
+        self.flags = flags;
+        self
+    }
+
+    /// Sets the `mask` option, replacing the default.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// tokio_uring::start(async {
+    ///     // Fetch file metadata
+    ///     let statx = tokio_uring::fs::StatxBuilder::new()
+    ///         .mask(libc::STATX_BASIC_STATS)
+    ///         .statx_path("foo.txt").await.unwrap();
+    /// })
+    /// ```
+    #[must_use]
+    pub fn mask(&mut self, mask: u32) -> &mut Self {
+        self.mask = mask;
+        self
+    }
+
+    /// Returns the metadata requested for the optional open file. If no open file was provided,
+    /// the metadata for the current working directory is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_uring::fs::File;
+    ///
+    /// tokio_uring::start(async {
+    ///     let f = File::create("foo.txt").await.unwrap();
+    ///
+    ///     // Fetch file metadata
+    ///     let statx = f.statx_builder()
+    ///         .mask(libc::STATX_TYPE)
+    ///         .statx().await.unwrap();
+    ///
+    ///     // Close the file
+    ///     f.close().await.unwrap();
+    /// })
+    /// ```
+    pub async fn statx(&self) -> io::Result<libc::statx> {
+        Op::statx(self.file.map(|x| &x.fd), None, self.flags, self.mask)?.await
+    }
+
+    // TODO should the statx() terminator be renamed to something like nopath()
+    // and the statx_path() be renamed to path(AsRef<Path>)?
+
+    /// Returns the metadata requested for the given path. The path can be absolute or relative.
+    ///
+    /// When the path is relative, it works against the open file discriptor if it has one
+    /// else it works against the current working directory.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// tokio_uring::start(async {
+    ///     // Fetch metadata for relative path against current working directory.
+    ///     let statx = tokio_uring::fs::StatxBuilder::new()
+    ///         .mask(libc::STATX_BASIC_STATS)
+    ///         .statx_path("foo.txt").await.unwrap();
+    /// })
+    /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// tokio_uring::start(async {
+    ///     // This shows the power of combining an open file, presumably a directory, and the relative
+    ///     // path to have the statx operation return the meta data for the child of the opened directory
+    ///     // descriptor.
+    ///     let dir_path = "/home/ubuntu";
+    ///     let rel_path = "./work";
+    ///
+    ///     let open_dir = tokio_uring::fs::File::open(dir_path).await.unwrap();
+    ///
+    ///     // Fetch metadata for relative path against open directory.
+    ///     let statx_res = open_dir.statx_builder().statx_path(rel_path).await;
+    ///
+    ///     // Close the directory descriptor.
+    ///     open_dir.close().await.unwrap();
+    ///
+    ///     // Use the relative path's statx information.
+    ///     let _ = statx_res.unwrap();
+    /// })
+    /// ```
+    pub async fn statx_path<P: AsRef<Path>>(&self, path: P) -> io::Result<libc::statx> {
+        // It's almost an accident there are two terminators for the StatxBuilder, one that doesn't
+        // take a path, and one that does.
+        //
+        // Because the <AsRef<Path>> is of unknown size, it can't be stored in the builder without
+        // boxing it, and the conversion to CString can't be done without potentially returning an
+        // error and returning an error can't be done by a method that returns a &mut self, and
+        // trying to return a Result<&mut self> may have led to trouble, but what really seemed
+        // like trouble was using the CString field in the other terminator. Have to look into this
+        // again.
+        use crate::io::cstr;
+
+        let path = cstr(path.as_ref())?;
+        Op::statx(self.file.map(|x| &x.fd), Some(path), self.flags, self.mask)?.await
+    }
+}
+
+// TODO consider replacing this with a Statx struct with useful helper methods.
+/// Returns two bools, is_dir and is_regfile.
+///
+/// They both can't be true at the same time and there are many reasons they may both be false.
+#[allow(dead_code)]
+pub async fn is_dir_regfile<P: AsRef<Path>>(path: P) -> (bool, bool) {
+    let res = crate::fs::StatxBuilder::new()
+        .mask(libc::STATX_TYPE)
+        .statx_path(path)
+        .await;
+    match res {
+        Ok(statx) => (
+            (u32::from(statx.stx_mode) & libc::S_IFMT) == libc::S_IFDIR,
+            (u32::from(statx.stx_mode) & libc::S_IFMT) == libc::S_IFREG,
+        ),
+        Err(_) => (false, false),
     }
 }

--- a/src/fs/statx.rs
+++ b/src/fs/statx.rs
@@ -1,0 +1,28 @@
+use super::File;
+use crate::runtime::driver::op::Op;
+use std::io;
+
+impl File {
+    /// Metadata information about a file.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_uring::fs::File;
+    ///
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     tokio_uring::start(async {
+    ///         let f = File::create("foo.txt").await?;
+    ///
+    ///         // Fetch file metadata
+    ///         let statx = f.statx().await?;
+    ///
+    ///         // Close the file
+    ///         f.close().await?;
+    ///         Ok(())
+    ///     })
+    /// }
+    pub async fn statx(&self) -> io::Result<libc::statx> {
+        Op::statx(&self.fd)?.await
+    }
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -43,6 +43,7 @@ mod statx;
 mod unlink_at;
 
 mod util;
+pub(crate) use util::cstr;
 
 mod write;
 

--- a/src/io/statx.rs
+++ b/src/io/statx.rs
@@ -15,6 +15,9 @@ pub(crate) struct Statx {
     fd: Option<SharedFd>,
     #[allow(dead_code)]
     path: CString,
+
+    // TODO consider returning this type when the operation is complete so the caller has the boxed value.
+    // The builder could even recycle an old boxed value and pass it in here.
     statx: Box<libc::statx>,
 }
 

--- a/src/io/statx.rs
+++ b/src/io/statx.rs
@@ -1,3 +1,4 @@
+use std::ffi::CString;
 use std::{ffi::CStr, io};
 
 use io_uring::{opcode, types};
@@ -10,27 +11,51 @@ use crate::runtime::{
 use super::SharedFd;
 
 pub(crate) struct Statx {
-    fd: SharedFd,
+    #[allow(dead_code)]
+    fd: Option<SharedFd>,
+    #[allow(dead_code)]
+    path: CString,
     statx: Box<libc::statx>,
 }
 
 impl Op<Statx> {
-    pub(crate) fn statx(fd: &SharedFd) -> io::Result<Op<Statx>> {
+    // If we are passed a reference to a shared fd, clone it so we keep it live during the
+    // Future. If we aren't, use the libc::AT_FDCWD value.
+    // If Path is None, the flags is combined with libc::AT_EMPTY_PATH automatically.
+    pub(crate) fn statx(
+        fd: Option<&SharedFd>,
+        path: Option<CString>,
+        flags: i32,
+        mask: u32,
+    ) -> io::Result<Op<Statx>> {
+        let (fd, raw) = match fd {
+            Some(shared) => (Some(shared.clone()), shared.raw_fd()),
+            None => (None, libc::AT_FDCWD),
+        };
+        let mut flags = flags;
+        let path = match path {
+            Some(path) => path,
+            None => {
+                flags |= libc::AT_EMPTY_PATH;
+                CStr::from_bytes_with_nul(b"\0").unwrap().into() // Is there a constant CString we
+                                                                 // could use here.
+            }
+        };
         CONTEXT.with(|x| {
-            let empty_path = CStr::from_bytes_with_nul(b"\0").unwrap();
             x.handle().expect("not in a runtime context").submit_op(
                 Statx {
-                    fd: fd.clone(),
+                    fd,
+                    path,
                     statx: Box::new(unsafe { std::mem::zeroed() }),
                 },
                 |statx| {
                     opcode::Statx::new(
-                        types::Fd(statx.fd.raw_fd()),
-                        empty_path.as_ptr(),
+                        types::Fd(raw),
+                        statx.path.as_ptr(),
                         &mut *statx.statx as *mut libc::statx as *mut types::statx,
                     )
-                    .flags(libc::AT_EMPTY_PATH)
-                    .mask(libc::STATX_ALL)
+                    .flags(flags)
+                    .mask(mask)
                     .build()
                 },
             )

--- a/src/io/util.rs
+++ b/src/io/util.rs
@@ -2,7 +2,7 @@ use std::ffi::CString;
 use std::io;
 use std::path::Path;
 
-pub(super) fn cstr(p: &Path) -> io::Result<CString> {
+pub(crate) fn cstr(p: &Path) -> io::Result<CString> {
     use std::os::unix::ffi::OsStrExt;
     Ok(CString::new(p.as_os_str().as_bytes())?)
 }


### PR DESCRIPTION
Add a builder for the statx command, tokio_uring::fs::StatxBuilder.

Also adds a tokio_uring::fs::statx() function.

Also adds test cases for these functions to the poorly named example: test_create_dir_all.