### PR TITLE
Simplify SharedFd close logic

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -850,8 +850,7 @@ impl File {
     /// }
     /// ```
     pub async fn close(self) -> io::Result<()> {
-        self.fd.close().await;
-        Ok(())
+        self.fd.close().await
     }
 }
 
@@ -863,14 +862,14 @@ impl FromRawFd for File {
 
 impl AsRawFd for File {
     fn as_raw_fd(&self) -> RawFd {
-        self.fd.raw_fd()
+        self.fd.as_raw_fd()
     }
 }
 
 impl fmt::Debug for File {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("File")
-            .field("fd", &self.fd.raw_fd())
+            .field("fd", &self.fd.as_raw_fd())
             .finish()
     }
 }

--- a/src/future.rs
+++ b/src/future.rs
@@ -1,3 +1,4 @@
+#[allow(unused_macros)]
 macro_rules! ready {
     ($e:expr $(,)?) => {
         match $e {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,7 +1,6 @@
 mod accept;
 
 mod close;
-pub(crate) use close::Close;
 
 mod connect;
 

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -33,6 +33,7 @@ impl RuntimeContext {
     }
 
     /// Check if driver is initialized
+    #[allow(dead_code)]
     pub(crate) fn is_set(&self) -> bool {
         self.driver
             .try_borrow()


### PR DESCRIPTION
Currently, the SharedFd close logic is needlessly complex. The logic within SharedFd that prevents a Fd from being closed while any IO operations are in-flight is unnecessary because the rust borrow checker already enforces this.