### PR TITLE
fix: rework SharedFd

### DIFF
--- a/src/future.rs
+++ b/src/future.rs
@@ -1,3 +1,5 @@
+// TODO see about removing or just commenting out.
+#[allow(unused_macros)]
 macro_rules! ready {
     ($e:expr $(,)?) => {
         match $e {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,7 +1,6 @@
 mod accept;
 
 mod close;
-pub(crate) use close::Close;
 
 mod connect;
 

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -33,6 +33,7 @@ impl RuntimeContext {
     }
 
     /// Check if driver is initialized
+    #[allow(dead_code)]
     pub(crate) fn is_set(&self) -> bool {
         self.driver
             .try_borrow()

--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -342,6 +342,6 @@ fn assert_invalid_fd(fd: RawFd) {
 
     match f.read_to_end(&mut buf) {
         Err(ref e) if e.raw_os_error() == Some(libc::EBADF) => {}
-        res => panic!("{:?}", res),
+        res => panic!("assert_invalid_fd finds for fd {:?}, res = {:?}", fd, res),
     }
 }


### PR DESCRIPTION
This allows a 'file.close.wait' to return a true close return value. And it fixes the problem of indefinitely hanging when the SharedFd was still held by an in-flight operation.

It simplifies the low level close logic, using the async uring close operation when the caller is using file.close.wait but using the synchronous close mechanism provided by the std library when the SharedFd is allowed to go out of scope without having been closed first.

Manual closing of the file should be encouraged because it allows the user to see the return code.

In order to let the file owner call close and not hang when an in-flight was still in progress, this reworks the future to return when it sees the strong reference count drop to 1.

Fixes 
- #122.