### PR TITLE
Make msghdr.msg_name optional

### DIFF
--- a/examples/udp_socket.rs
+++ b/examples/udp_socket.rs
@@ -20,7 +20,7 @@ fn main() {
         buf.resize(read, 0);
         println!("received from {}: {:?}", socket_addr, &buf[..]);
 
-        let (result, _buf) = socket.send_to(buf, Some(socket_addr)).await;
+        let (result, _buf) = socket.send_to(buf, socket_addr).await;
         println!("sent to {}: {}", socket_addr, result.unwrap());
     });
 }

--- a/examples/udp_socket.rs
+++ b/examples/udp_socket.rs
@@ -20,7 +20,7 @@ fn main() {
         buf.resize(read, 0);
         println!("received from {}: {:?}", socket_addr, &buf[..]);
 
-        let (result, _buf) = socket.send_to(buf, socket_addr).await;
+        let (result, _buf) = socket.send_to(buf, Some(socket_addr)).await;
         println!("sent to {}: {}", socket_addr, result.unwrap());
     });
 }

--- a/src/io/socket.rs
+++ b/src/io/socket.rs
@@ -136,7 +136,7 @@ impl Socket {
     pub(crate) async fn send_to<T: BoundedBuf>(
         &self,
         buf: T,
-        socket_addr: SocketAddr,
+        socket_addr: Option<SocketAddr>,
     ) -> crate::BufResult<usize, T> {
         let op = Op::send_to(&self.fd, buf, socket_addr).unwrap();
         op.await
@@ -150,7 +150,7 @@ impl Socket {
     pub(crate) async fn sendmsg_zc<T: BoundedBuf, U: BoundedBuf>(
         &self,
         io_slices: Vec<T>,
-        socket_addr: SocketAddr,
+        socket_addr: Option<SocketAddr>,
         msg_control: Option<U>,
     ) -> (io::Result<usize>, Vec<T>, Option<U>) {
         let op = Op::sendmsg_zc(&self.fd, io_slices, socket_addr, msg_control).unwrap();

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -261,6 +261,9 @@ impl UdpSocket {
     /// > it replaces per byte copy cost with page accounting and completion
     /// > notification overhead. As a result, zero copy is generally only effective
     /// > at writes over around 10 KB.
+    ///
+    /// Can be used with socket_addr: None on connected sockets, which can have performance
+    /// benefits if multiple datagrams are sent to the same destination address.
     pub async fn sendmsg_zc<T: BoundedBuf, U: BoundedBuf>(
         &self,
         io_slices: Vec<T>,

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -72,7 +72,7 @@ use std::{
 ///         let buf = vec![0; 32];
 ///
 ///         // write data
-///         let (result, _) = socket.send_to(b"hello world".as_slice(), second_addr).await;
+///         let (result, _) = socket.send_to(b"hello world".as_slice(), Some(second_addr)).await;
 ///         result.unwrap();
 ///
 ///         // read data
@@ -162,7 +162,7 @@ impl UdpSocket {
     ///
     ///         // write data
     ///         let (result, _) = std_socket
-    ///             .send_to(b"hello world".as_slice(), second_addr)
+    ///             .send_to(b"hello world".as_slice(), Some(second_addr))
     ///             .await;
     ///         result.unwrap();
     ///

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -211,10 +211,7 @@ impl UdpSocket {
     /// Sends data on the connected socket
     ///
     /// On success, returns the number of bytes written.
-    pub async fn send<T: BoundedBuf>(
-        &self,
-        buf: T,
-    ) -> crate::BufResult<usize, T> {
+    pub async fn send<T: BoundedBuf>(&self, buf: T) -> crate::BufResult<usize, T> {
         self.inner.send_to(buf, None).await
     }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -51,6 +51,16 @@ use std::{
 ///
 ///         assert_eq!(b"hello world", &buf[..n_bytes]);
 ///
+///         // write data using send on connected socket
+///         let (result, _) = socket.send_to(b"hello world via send".as_slice(), None).await;
+///         result.unwrap();
+///
+///         // read data
+///         let (result, buf) = other_socket.read(buf).await;
+///         let n_bytes = result.unwrap();
+///
+///         assert_eq!(b"hello world via send", &buf[..n_bytes]);
+///
 ///         Ok(())
 ///     })
 /// }
@@ -198,7 +208,7 @@ impl UdpSocket {
         self.inner.connect(SockAddr::from(socket_addr)).await
     }
 
-    /// Sends data on the socket to the given address.
+    /// Sends data on the socket to the given address or to previously connected remote peer.
     ///
     /// On success, returns the number of bytes written.
     pub async fn send_to<T: BoundedBuf>(

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -204,7 +204,7 @@ impl UdpSocket {
     pub async fn send_to<T: BoundedBuf>(
         &self,
         buf: T,
-        socket_addr: SocketAddr,
+        socket_addr: Option<SocketAddr>,
     ) -> crate::BufResult<usize, T> {
         self.inner.send_to(buf, socket_addr).await
     }
@@ -246,7 +246,7 @@ impl UdpSocket {
     pub async fn sendmsg_zc<T: BoundedBuf, U: BoundedBuf>(
         &self,
         io_slices: Vec<T>,
-        socket_addr: SocketAddr,
+        socket_addr: Option<SocketAddr>,
         msg_control: Option<U>,
     ) -> (io::Result<usize>, Vec<T>, Option<U>) {
         self.inner

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -215,7 +215,7 @@ impl UdpSocket {
         self.inner.send_to(buf, None).await
     }
 
-    /// Sends data on the socket to the given address or to previously connected remote peer.
+    /// Sends data on the socket to the given address.
     ///
     /// On success, returns the number of bytes written.
     pub async fn send_to<T: BoundedBuf>(


### PR DESCRIPTION
sendmsg can be used on connected sockets without msg_name.