### PR TITLE
bump io-uring to 0.5.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ keywords = ["async", "fs", "io-uring"]
 tokio = { version = "1.2", features = ["net", "rt", "sync"] }
 slab = "0.4.2"
 libc = "0.2.80"
-io-uring = { version = "0.5.12", features = ["unstable"] }
+io-uring = "0.5.13"
 socket2 = { version = "0.4.4", features = ["all"] }
 bytes = { version = "1.0", optional = true }
 futures = "0.3.26"


### PR DESCRIPTION
And remove the io-uring "unstable" features dependency as it is deprecated.