### PR TITLE
rt: add new api for oneshot op submission and creation

### DIFF
--- a/examples/mix.rs
+++ b/examples/mix.rs
@@ -41,7 +41,7 @@ fn main() {
                         break;
                     }
 
-                    let (res, b) = socket.write(b).await;
+                    let (res, b) = socket.write(b).submit().await;
                     pos += res.unwrap() as u64;
 
                     buf = b;

--- a/examples/tcp_stream.rs
+++ b/examples/tcp_stream.rs
@@ -15,7 +15,7 @@ fn main() {
         let stream = TcpStream::connect(socket_addr).await.unwrap();
         let buf = vec![1u8; 128];
 
-        let (result, buf) = stream.write(buf).await;
+        let (result, buf) = stream.write(buf).submit().await;
         println!("written: {}", result.unwrap());
 
         let (result, buf) = stream.read(buf).await;

--- a/examples/unix_listener.rs
+++ b/examples/unix_listener.rs
@@ -20,7 +20,7 @@ fn main() {
             tokio_uring::spawn(async move {
                 let buf = vec![1u8; 128];
 
-                let (result, buf) = stream.write(buf).await;
+                let (result, buf) = stream.write(buf).submit().await;
                 println!("written to {}: {}", &socket_addr, result.unwrap());
 
                 let (result, buf) = stream.read(buf).await;

--- a/examples/unix_stream.rs
+++ b/examples/unix_stream.rs
@@ -15,7 +15,7 @@ fn main() {
         let stream = UnixStream::connect(socket_addr).await.unwrap();
         let buf = vec![1u8; 128];
 
-        let (result, buf) = stream.write(buf).await;
+        let (result, buf) = stream.write(buf).submit().await;
         println!("written: {}", result.unwrap());
 
         let (result, buf) = stream.read(buf).await;

--- a/examples/wrk-bench.rs
+++ b/examples/wrk-bench.rs
@@ -21,7 +21,7 @@ fn main() -> io::Result<()> {
                     let (stream, _) = listener.accept().await?;
 
                     tokio_uring::spawn(async move {
-                        let (result, _) = stream.write(RESPONSE).await;
+                        let (result, _) = stream.write(RESPONSE).submit().await;
 
                         if let Err(err) = result {
                             eprintln!("Client connection failed: {}", err);

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -39,7 +39,7 @@ use std::path::Path;
 ///         let file = File::create("hello.txt").await?;
 ///
 ///         // Write some data
-///         let (res, buf) = file.write_at(&b"hello world"[..], 0).await;
+///         let (res, buf) = file.write_at(&b"hello world"[..], 0).submit().await;
 ///         let n = res?;
 ///
 ///         println!("wrote {} bytes", n);
@@ -526,7 +526,7 @@ impl File {
     ///         let file = File::create("foo.txt").await?;
     ///
     ///         // Writes some prefix of the byte string, not necessarily all of it.
-    ///         let (res, _) = file.write_at(&b"some bytes"[..], 0).await;
+    ///         let (res, _) = file.write_at(&b"some bytes"[..], 0).submit().await;
     ///         let n = res?;
     ///
     ///         println!("wrote {} bytes", n);
@@ -773,7 +773,7 @@ impl File {
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     tokio_uring::start(async {
     ///         let f = File::create("foo.txt").await?;
-    ///         let (res, buf) = f.write_at(&b"Hello, world!"[..], 0).await;
+    ///         let (res, buf) = f.write_at(&b"Hello, world!"[..], 0).submit().await;
     ///         let n = res?;
     ///
     ///         f.sync_all().await?;
@@ -810,7 +810,7 @@ impl File {
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     tokio_uring::start(async {
     ///         let f = File::create("foo.txt").await?;
-    ///         let (res, buf) = f.write_at(&b"Hello, world!"[..], 0).await;
+    ///         let (res, buf) = f.write_at(&b"Hello, world!"[..], 0).submit().await;
     ///         let n = res?;
     ///
     ///         f.sync_data().await?;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -44,7 +44,7 @@ mod unlink_at;
 mod util;
 pub(crate) use util::cstr;
 
-mod write;
+pub(crate) mod write;
 
 mod write_fixed;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub mod buf;
 pub mod fs;
 pub mod net;
 
+pub use runtime::driver::op::{InFlightOneshot, OneshotOutputTransform, UnsubmittedOneshot};
 pub use runtime::spawn;
 pub use runtime::Runtime;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub mod buf;
 pub mod fs;
 pub mod net;
 
+pub use io::write::*;
 pub use runtime::driver::op::{InFlightOneshot, OneshotOutputTransform, UnsubmittedOneshot};
 pub use runtime::spawn;
 pub use runtime::Runtime;

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -29,7 +29,7 @@ use std::{io, net::SocketAddr};
 ///     let tx = TcpStream::connect("127.0.0.1:2345".parse().unwrap()).await.unwrap();
 ///     let rx = rx_ch.await.expect("The spawned task expected to send a TcpStream");
 ///
-///     tx.write(b"test" as &'static [u8]).await.0.unwrap();
+///     tx.write(b"test" as &'static [u8]).submit().await.0.unwrap();
 ///
 ///     let (_, buf) = rx.read(vec![0; 4]).await;
 ///

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -8,6 +8,7 @@ use crate::{
     buf::fixed::FixedBuf,
     buf::{BoundedBuf, BoundedBufMut},
     io::{SharedFd, Socket},
+    UnsubmittedWrite,
 };
 
 /// A TCP stream between a local and a remote socket.
@@ -100,8 +101,8 @@ impl TcpStream {
     /// Write some data to the stream from the buffer.
     ///
     /// Returns the original buffer and quantity of data written.
-    pub async fn write<T: BoundedBuf>(&self, buf: T) -> crate::BufResult<usize, T> {
-        self.inner.write(buf).await
+    pub fn write<T: BoundedBuf>(&self, buf: T) -> UnsubmittedWrite<T> {
+        self.inner.write(buf)
     }
 
     /// Attempts to write an entire buffer to the stream.

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -28,7 +28,7 @@ use crate::{
 ///         let mut stream = TcpStream::connect("127.0.0.1:8080".parse().unwrap()).await?;
 ///
 ///         // Write some data.
-///         let (result, _) = stream.write(b"hello world!".as_slice()).await;
+///         let (result, _) = stream.write(b"hello world!".as_slice()).submit().await;
 ///         result.unwrap();
 ///
 ///         Ok(())

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -43,7 +43,7 @@ use std::{
 ///         let buf = vec![0; 32];
 ///
 ///         // write data
-///         let (result, _) = socket.write(b"hello world".as_slice()).await;
+///         let (result, _) = socket.write(b"hello world".as_slice()).submit().await;
 ///         result.unwrap();
 ///
 ///         // read data

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -2,6 +2,7 @@ use crate::{
     buf::fixed::FixedBuf,
     buf::{BoundedBuf, BoundedBufMut},
     io::{SharedFd, Socket},
+    UnsubmittedWrite,
 };
 use socket2::SockAddr;
 use std::{
@@ -312,8 +313,8 @@ impl UdpSocket {
     /// Writes data into the socket from the specified buffer.
     ///
     /// Returns the original buffer and quantity of data written.
-    pub async fn write<T: BoundedBuf>(&self, buf: T) -> crate::BufResult<usize, T> {
-        self.inner.write(buf).await
+    pub fn write<T: BoundedBuf>(&self, buf: T) -> UnsubmittedWrite<T> {
+        self.inner.write(buf)
     }
 
     /// Writes data into the socket from a registered buffer.

--- a/src/net/unix/listener.rs
+++ b/src/net/unix/listener.rs
@@ -30,7 +30,7 @@ use std::{io, path::Path};
 ///     let tx = UnixStream::connect(&sock_file).await.unwrap();
 ///     let rx = rx_ch.await.expect("The spawned task expected to send a UnixStream");
 ///
-///     tx.write(b"test" as &'static [u8]).await.0.unwrap();
+///     tx.write(b"test" as &'static [u8]).submit().await.0.unwrap();
 ///
 ///     let (_, buf) = rx.read(vec![0; 4]).await;
 ///

--- a/src/net/unix/stream.rs
+++ b/src/net/unix/stream.rs
@@ -2,6 +2,7 @@ use crate::{
     buf::fixed::FixedBuf,
     buf::{BoundedBuf, BoundedBufMut},
     io::{SharedFd, Socket},
+    UnsubmittedWrite,
 };
 use socket2::SockAddr;
 use std::{
@@ -98,8 +99,8 @@ impl UnixStream {
 
     /// Write some data to the stream from the buffer, returning the original buffer and
     /// quantity of data written.
-    pub async fn write<T: BoundedBuf>(&self, buf: T) -> crate::BufResult<usize, T> {
-        self.inner.write(buf).await
+    pub fn write<T: BoundedBuf>(&self, buf: T) -> UnsubmittedWrite<T> {
+        self.inner.write(buf)
     }
 
     /// Attempts to write an entire buffer to the stream.

--- a/src/net/unix/stream.rs
+++ b/src/net/unix/stream.rs
@@ -28,7 +28,7 @@ use std::{
 ///         let mut stream = UnixStream::connect("/tmp/tokio-uring-unix-test.sock").await?;
 ///
 ///         // Write some data.
-///         let (result, _) = stream.write(b"hello world!".as_slice()).await;
+///         let (result, _) = stream.write(b"hello world!".as_slice()).submit().await;
 ///         result.unwrap();
 ///
 ///         Ok(())

--- a/src/runtime/driver/handle.rs
+++ b/src/runtime/driver/handle.rs
@@ -100,6 +100,10 @@ impl Handle {
     pub(crate) fn remove_op<T, CqeType>(&self, op: &mut Op<T, CqeType>) {
         self.inner.borrow_mut().remove_op(op)
     }
+
+    pub(crate) fn remove_op_2<T: 'static>(&self, index: usize, data: T) {
+        self.inner.borrow_mut().remove_op_2(index, data)
+    }
 }
 
 impl WeakHandle {

--- a/src/runtime/driver/handle.rs
+++ b/src/runtime/driver/handle.rs
@@ -12,7 +12,7 @@
 //! The weak handle should be used by anything which is stored in the driver or does not need to
 //! keep the driver alive for it's duration.
 
-use io_uring::squeue;
+use io_uring::{cqueue, squeue};
 use std::cell::RefCell;
 use std::io;
 use std::ops::Deref;
@@ -63,6 +63,10 @@ impl Handle {
         self.inner.borrow_mut().unregister_buffers(buffers)
     }
 
+    pub(crate) fn submit_op_2(&self, sqe: squeue::Entry) -> usize {
+        self.inner.borrow_mut().submit_op_2(sqe)
+    }
+
     pub(crate) fn submit_op<T, S, F>(&self, data: T, f: F) -> io::Result<Op<T, S>>
     where
         T: Completable,
@@ -76,6 +80,10 @@ impl Handle {
         T: Unpin + 'static + Completable,
     {
         self.inner.borrow_mut().poll_op(op, cx)
+    }
+
+    pub(crate) fn poll_op_2(&self, index: usize, cx: &mut Context<'_>) -> Poll<cqueue::Entry> {
+        self.inner.borrow_mut().poll_op_2(index, cx)
     }
 
     pub(crate) fn poll_multishot_op<T>(

--- a/src/runtime/driver/mod.rs
+++ b/src/runtime/driver/mod.rs
@@ -501,204 +501,199 @@ impl Drop for Ops {
     }
 }
 
-// #[cfg(test)]
-// mod test {
-//     use std::rc::Rc;
-//
-//     use crate::runtime::driver::op::{Completable, CqeResult, Op};
-//     use crate::runtime::CONTEXT;
-//     use tokio_test::{assert_pending, assert_ready, task};
-//
-//     use super::*;
-//
-//     #[derive(Debug)]
-//     pub(crate) struct Completion {
-//         result: io::Result<u32>,
-//         flags: u32,
-//         data: Rc<()>,
-//     }
-//
-//     impl Completable for Rc<()> {
-//         type Output = Completion;
-//
-//         fn complete(self, cqe: CqeResult) -> Self::Output {
-//             Completion {
-//                 result: cqe.result,
-//                 flags: cqe.flags,
-//                 data: self.clone(),
-//             }
-//         }
-//     }
-//
-//     #[test]
-//     fn op_stays_in_slab_on_drop() {
-//         let (op, data) = init();
-//         drop(op);
-//
-//         assert_eq!(2, Rc::strong_count(&data));
-//
-//         assert_eq!(1, num_operations());
-//         release();
-//     }
-//
-//     #[test]
-//     fn poll_op_once() {
-//         let (op, data) = init();
-//         let mut op = task::spawn(op);
-//         assert_pending!(op.poll());
-//         assert_eq!(2, Rc::strong_count(&data));
-//
-//         complete(&op, Ok(1));
-//         assert_eq!(1, num_operations());
-//         assert_eq!(2, Rc::strong_count(&data));
-//
-//         assert!(op.is_woken());
-//         let Completion {
-//             result,
-//             flags,
-//             data: d,
-//         } = assert_ready!(op.poll());
-//         assert_eq!(2, Rc::strong_count(&data));
-//         assert_eq!(1, result.unwrap());
-//         assert_eq!(0, flags);
-//
-//         drop(d);
-//         assert_eq!(1, Rc::strong_count(&data));
-//
-//         drop(op);
-//         assert_eq!(0, num_operations());
-//
-//         release();
-//     }
-//
-//     #[test]
-//     fn poll_op_twice() {
-//         {
-//             let (op, ..) = init();
-//             let mut op = task::spawn(op);
-//             assert_pending!(op.poll());
-//             assert_pending!(op.poll());
-//
-//             complete(&op, Ok(1));
-//
-//             assert!(op.is_woken());
-//             let Completion { result, flags, .. } = assert_ready!(op.poll());
-//             assert_eq!(1, result.unwrap());
-//             assert_eq!(0, flags);
-//         }
-//
-//         release();
-//     }
-//
-//     #[test]
-//     fn poll_change_task() {
-//         {
-//             let (op, ..) = init();
-//             let mut op = task::spawn(op);
-//             assert_pending!(op.poll());
-//
-//             let op = op.into_inner();
-//             let mut op = task::spawn(op);
-//             assert_pending!(op.poll());
-//
-//             complete(&op, Ok(1));
-//
-//             assert!(op.is_woken());
-//             let Completion { result, flags, .. } = assert_ready!(op.poll());
-//             assert_eq!(1, result.unwrap());
-//             assert_eq!(0, flags);
-//         }
-//
-//         release();
-//     }
-//
-//     #[test]
-//     fn complete_before_poll() {
-//         let (op, data) = init();
-//         let mut op = task::spawn(op);
-//         complete(&op, Ok(1));
-//         assert_eq!(1, num_operations());
-//         assert_eq!(2, Rc::strong_count(&data));
-//
-//         let Completion { result, flags, .. } = assert_ready!(op.poll());
-//         assert_eq!(1, result.unwrap());
-//         assert_eq!(0, flags);
-//
-//         drop(op);
-//         assert_eq!(0, num_operations());
-//
-//         release();
-//     }
-//
-//     #[test]
-//     fn complete_after_drop() {
-//         let (op, data) = init();
-//         let index = op.index();
-//         drop(op);
-//
-//         assert_eq!(2, Rc::strong_count(&data));
-//
-//         assert_eq!(1, num_operations());
-//
-//         let cqe = CqeResult {
-//             result: Ok(1),
-//             flags: 0,
-//         };
-//
-//         CONTEXT.with(|cx| {
-//             cx.handle()
-//                 .unwrap()
-//                 .inner
-//                 .borrow_mut()
-//                 .ops
-//                 .complete(index, cqe)
-//         });
-//
-//         assert_eq!(1, Rc::strong_count(&data));
-//         assert_eq!(0, num_operations());
-//
-//         release();
-//     }
-//
-//     fn init() -> (Op<Rc<()>>, Rc<()>) {
-//         let driver = Driver::new(&crate::builder()).unwrap();
-//         let data = Rc::new(());
-//
-//         let op = CONTEXT.with(|cx| {
-//             cx.set_handle(driver.into());
-//
-//             let driver = cx.handle().unwrap();
-//
-//             let index = driver.inner.borrow_mut().ops.insert();
-//
-//             Op::new((&driver).into(), data.clone(), index)
-//         });
-//
-//         (op, data)
-//     }
-//
-//     fn num_operations() -> usize {
-//         CONTEXT.with(|cx| cx.handle().unwrap().inner.borrow().num_operations())
-//     }
-//
-//     fn complete(op: &Op<Rc<()>>, result: io::Result<u32>) {
-//         let cqe = CqeResult { result, flags: 0 };
-//
-//         CONTEXT.with(|cx| {
-//             let driver = cx.handle().unwrap();
-//
-//             driver.inner.borrow_mut().ops.complete(op.index(), cqe);
-//         });
-//     }
-//
-//     fn release() {
-//         CONTEXT.with(|cx| {
-//             let driver = cx.handle().unwrap();
-//
-//             driver.inner.borrow_mut().ops.lifecycle.clear();
-//             driver.inner.borrow_mut().ops.completions.clear();
-//
-//             cx.unset_driver();
-//         });
-//     }
-// }
+#[cfg(test)]
+mod test {
+    use std::rc::Rc;
+
+    use crate::runtime::driver::op::{Completable, CqeResult, Op};
+    use crate::runtime::CONTEXT;
+    use tokio_test::{assert_pending, assert_ready, task};
+
+    use super::*;
+
+    #[derive(Debug)]
+    pub(crate) struct Completion {
+        result: io::Result<u32>,
+        flags: u32,
+        data: Rc<()>,
+    }
+
+    impl Completable for Rc<()> {
+        type Output = Completion;
+
+        fn complete(self, cqe: CqeResult) -> Self::Output {
+            Completion {
+                result: cqe.result,
+                flags: cqe.flags,
+                data: self.clone(),
+            }
+        }
+    }
+
+    #[test]
+    fn op_stays_in_slab_on_drop() {
+        let (op, data) = init();
+        drop(op);
+
+        assert_eq!(2, Rc::strong_count(&data));
+
+        assert_eq!(1, num_operations());
+        release();
+    }
+
+    #[test]
+    fn poll_op_once() {
+        let (op, data) = init();
+        let mut op = task::spawn(op);
+        assert_pending!(op.poll());
+        assert_eq!(2, Rc::strong_count(&data));
+
+        complete(&op);
+        assert_eq!(1, num_operations());
+        assert_eq!(2, Rc::strong_count(&data));
+
+        assert!(op.is_woken());
+        let Completion {
+            result,
+            flags,
+            data: d,
+        } = assert_ready!(op.poll());
+        assert_eq!(2, Rc::strong_count(&data));
+        assert_eq!(0, result.unwrap());
+        assert_eq!(0, flags);
+
+        drop(d);
+        assert_eq!(1, Rc::strong_count(&data));
+
+        drop(op);
+        assert_eq!(0, num_operations());
+
+        release();
+    }
+
+    #[test]
+    fn poll_op_twice() {
+        {
+            let (op, ..) = init();
+            let mut op = task::spawn(op);
+            assert_pending!(op.poll());
+            assert_pending!(op.poll());
+
+            complete(&op);
+
+            assert!(op.is_woken());
+            let Completion { result, flags, .. } = assert_ready!(op.poll());
+            assert_eq!(0, result.unwrap());
+            assert_eq!(0, flags);
+        }
+
+        release();
+    }
+
+    #[test]
+    fn poll_change_task() {
+        {
+            let (op, ..) = init();
+            let mut op = task::spawn(op);
+            assert_pending!(op.poll());
+
+            let op = op.into_inner();
+            let mut op = task::spawn(op);
+            assert_pending!(op.poll());
+
+            complete(&op);
+
+            assert!(op.is_woken());
+            let Completion { result, flags, .. } = assert_ready!(op.poll());
+            assert_eq!(0, result.unwrap());
+            assert_eq!(0, flags);
+        }
+
+        release();
+    }
+
+    #[test]
+    fn complete_before_poll() {
+        let (op, data) = init();
+        let mut op = task::spawn(op);
+        complete(&op);
+        assert_eq!(1, num_operations());
+        assert_eq!(2, Rc::strong_count(&data));
+
+        let Completion { result, flags, .. } = assert_ready!(op.poll());
+        assert_eq!(0, result.unwrap());
+        assert_eq!(0, flags);
+
+        drop(op);
+        assert_eq!(0, num_operations());
+
+        release();
+    }
+
+    #[test]
+    fn complete_after_drop() {
+        let (op, data) = init();
+        let index = op.index();
+        drop(op);
+
+        assert_eq!(2, Rc::strong_count(&data));
+
+        assert_eq!(1, num_operations());
+
+        CONTEXT.with(|cx| {
+            cx.handle()
+                .unwrap()
+                .inner
+                .borrow_mut()
+                .ops
+                .complete(index, unsafe { mem::zeroed() })
+        });
+
+        assert_eq!(1, Rc::strong_count(&data));
+        assert_eq!(0, num_operations());
+
+        release();
+    }
+
+    fn init() -> (Op<Rc<()>>, Rc<()>) {
+        let driver = Driver::new(&crate::builder()).unwrap();
+        let data = Rc::new(());
+
+        let op = CONTEXT.with(|cx| {
+            cx.set_handle(driver.into());
+
+            let driver = cx.handle().unwrap();
+
+            let index = driver.inner.borrow_mut().ops.insert();
+
+            Op::new((&driver).into(), data.clone(), index)
+        });
+
+        (op, data)
+    }
+
+    fn num_operations() -> usize {
+        CONTEXT.with(|cx| cx.handle().unwrap().inner.borrow().num_operations())
+    }
+
+    fn complete(op: &Op<Rc<()>>) {
+        let cqe = unsafe { mem::zeroed() };
+
+        CONTEXT.with(|cx| {
+            let driver = cx.handle().unwrap();
+
+            driver.inner.borrow_mut().ops.complete(op.index(), cqe);
+        });
+    }
+
+    fn release() {
+        CONTEXT.with(|cx| {
+            let driver = cx.handle().unwrap();
+
+            driver.inner.borrow_mut().ops.lifecycle.clear();
+            driver.inner.borrow_mut().ops.completions.clear();
+
+            cx.unset_driver();
+        });
+    }
+}

--- a/src/runtime/driver/mod.rs
+++ b/src/runtime/driver/mod.rs
@@ -89,7 +89,7 @@ impl Driver {
 
             let index = cqe.user_data() as _;
 
-            self.ops.complete(index, cqe.into());
+            self.ops.complete(index, cqe);
         }
     }
 

--- a/src/runtime/driver/mod.rs
+++ b/src/runtime/driver/mod.rs
@@ -4,10 +4,10 @@ use io_uring::opcode::AsyncCancel;
 use io_uring::{cqueue, squeue, IoUring};
 use slab::Slab;
 use std::cell::RefCell;
-use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::rc::Rc;
 use std::task::{Context, Poll};
+use std::{io, mem};
 
 pub(crate) use handle::*;
 
@@ -122,6 +122,21 @@ impl Driver {
         ))
     }
 
+    pub(crate) fn submit_op_2(&mut self, sqe: squeue::Entry) -> usize {
+        let index = self.ops.insert();
+
+        // Configure the SQE
+        let sqe = sqe.user_data(index as _);
+
+        // Push the new operation
+        while unsafe { self.uring.submission().push(&sqe).is_err() } {
+            // If the submission queue is full, flush it to the kernel
+            self.submit().expect("Internal error, failed to submit ops");
+        }
+
+        index
+    }
+
     pub(crate) fn submit_op<T, S, F>(
         &mut self,
         mut data: T,
@@ -150,8 +165,6 @@ impl Driver {
     }
 
     pub(crate) fn remove_op<T, CqeType>(&mut self, op: &mut Op<T, CqeType>) {
-        use std::mem;
-
         // Get the Op Lifecycle state from the driver
         let (lifecycle, completions) = match self.ops.get_mut(op.index()) {
             Some(val) => val,
@@ -186,12 +199,37 @@ impl Driver {
         }
     }
 
+    pub(crate) fn poll_op_2(&mut self, index: usize, cx: &mut Context<'_>) -> Poll<cqueue::Entry> {
+        let (lifecycle, _) = self.ops.get_mut(index).expect("invalid internal state");
+
+        match mem::replace(lifecycle, Lifecycle::Submitted) {
+            Lifecycle::Submitted => {
+                *lifecycle = Lifecycle::Waiting(cx.waker().clone());
+                Poll::Pending
+            }
+            Lifecycle::Waiting(waker) if !waker.will_wake(cx.waker()) => {
+                *lifecycle = Lifecycle::Waiting(cx.waker().clone());
+                Poll::Pending
+            }
+            Lifecycle::Waiting(waker) => {
+                *lifecycle = Lifecycle::Waiting(waker);
+                Poll::Pending
+            }
+            Lifecycle::Ignored(..) => unreachable!(),
+            Lifecycle::Completed(cqe) => {
+                self.ops.remove(index);
+                Poll::Ready(cqe)
+            }
+            Lifecycle::CompletionList(..) => {
+                unreachable!("No `more` flag set for SingleCQE")
+            }
+        }
+    }
+
     pub(crate) fn poll_op<T>(&mut self, op: &mut Op<T>, cx: &mut Context<'_>) -> Poll<T::Output>
     where
         T: Unpin + 'static + Completable,
     {
-        use std::mem;
-
         let (lifecycle, _) = self
             .ops
             .get_mut(op.index())
@@ -213,7 +251,7 @@ impl Driver {
             Lifecycle::Ignored(..) => unreachable!(),
             Lifecycle::Completed(cqe) => {
                 self.ops.remove(op.index());
-                Poll::Ready(op.take_data().unwrap().complete(cqe))
+                Poll::Ready(op.take_data().unwrap().complete(cqe.into()))
             }
             Lifecycle::CompletionList(..) => {
                 unreachable!("No `more` flag set for SingleCQE")
@@ -229,8 +267,6 @@ impl Driver {
     where
         T: Unpin + 'static + Completable + Updateable,
     {
-        use std::mem;
-
         let (lifecycle, completions) = self
             .ops
             .get_mut(op.index())
@@ -254,7 +290,7 @@ impl Driver {
                 // This is possible. We may have previously polled a CompletionList,
                 // and the final CQE registered as Completed
                 self.ops.remove(op.index());
-                Poll::Ready(op.take_data().unwrap().complete(cqe))
+                Poll::Ready(op.take_data().unwrap().complete(cqe.into()))
             }
             Lifecycle::CompletionList(indices) => {
                 let mut data = op.take_data().unwrap();
@@ -322,10 +358,9 @@ impl Drop for Driver {
                     let mut list = indices.clone().into_list(&mut self.ops.completions);
                     if !io_uring::cqueue::more(list.peek_end().unwrap().flags) {
                         // This op is complete. Replace with a null Completed entry
-                        *cycle = Lifecycle::Completed(op::CqeResult {
-                            result: Ok(0),
-                            flags: 0,
-                        });
+                        // safety: zeroed memory is entirely valid with this underlying
+                        // representation
+                        *cycle = Lifecycle::Completed(unsafe { mem::zeroed() });
                     }
                 }
 
@@ -414,7 +449,7 @@ impl Ops {
         self.lifecycle.remove(index);
     }
 
-    fn complete(&mut self, index: usize, cqe: op::CqeResult) {
+    fn complete(&mut self, index: usize, cqe: cqueue::Entry) {
         let completions = &mut self.completions;
         if self.lifecycle[index].complete(completions, cqe) {
             self.lifecycle.remove(index);

--- a/src/runtime/driver/op/mod.rs
+++ b/src/runtime/driver/op/mod.rs
@@ -4,14 +4,14 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll, Waker};
 
-use io_uring::cqueue;
+use io_uring::{cqueue, squeue};
 
 mod slab_list;
 
 use slab::Slab;
 use slab_list::{SlabListEntry, SlabListIndices};
 
-use crate::runtime::driver;
+use crate::runtime::{driver, CONTEXT};
 
 /// A SlabList is used to hold unserved completions.
 ///
@@ -19,6 +19,100 @@ use crate::runtime::driver;
 /// which require an unknown number of CQE events to be
 /// captured before completion.
 pub(crate) type Completion = SlabListEntry<CqeResult>;
+
+/// An unsubmitted oneshot operation.
+pub struct UnsubmittedOneshot<D, T: OneshotOutputTransform<StoredData = D>> {
+    stable_data: D,
+    post_op: T,
+    sqe: squeue::Entry,
+}
+
+impl<D, T: OneshotOutputTransform<StoredData = D>> UnsubmittedOneshot<D, T> {
+    /// Construct a new operation for later submission.
+    pub fn new(stable_data: D, post_op: T, sqe: squeue::Entry) -> Self {
+        Self {
+            stable_data,
+            post_op,
+            sqe,
+        }
+    }
+
+    /// Submit an operation to the driver for batched entry to the kernel.
+    pub fn submit(self) -> InFlightOneshot<D, T> {
+        let handle = CONTEXT
+            .with(|x| x.handle())
+            .expect("Could not submit op; not in runtime context");
+
+        self.submit_with_driver(&handle)
+    }
+
+    fn submit_with_driver(self, driver: &driver::Handle) -> InFlightOneshot<D, T> {
+        let index = driver.submit_op_2(self.sqe);
+
+        let driver = driver.into();
+
+        let inner = InFlightOneshotInner {
+            index,
+            driver,
+            stable_data: self.stable_data,
+            post_op: self.post_op,
+        };
+
+        InFlightOneshot { inner: Some(inner) }
+    }
+}
+
+/// An in-progress oneshot operation which can be polled for completion.
+pub struct InFlightOneshot<D, T: OneshotOutputTransform<StoredData = D>> {
+    inner: Option<InFlightOneshotInner<D, T>>,
+}
+
+struct InFlightOneshotInner<D, T: OneshotOutputTransform<StoredData = D>> {
+    driver: driver::WeakHandle,
+    index: usize,
+    stable_data: D,
+    post_op: T,
+}
+
+impl<D: Unpin, T: OneshotOutputTransform<StoredData = D> + Unpin> Future for InFlightOneshot<D, T> {
+    type Output = T::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        let inner = this
+            .inner
+            .as_mut()
+            .expect("Cannot poll already-completed operation");
+
+        let index = inner.index;
+
+        let upgraded = inner
+            .driver
+            .upgrade()
+            .expect("Failed to poll op: driver no longer exists");
+
+        let cqe = ready!(upgraded.poll_op_2(index, cx));
+
+        let inner = this.inner.take().unwrap();
+
+        Poll::Ready(
+            inner
+                .post_op
+                .transform_oneshot_output(inner.stable_data, cqe),
+        )
+    }
+}
+
+/// Transforms the output of a oneshot operation into a more user-friendly format.
+pub trait OneshotOutputTransform {
+    /// The final output after the transformation.
+    type Output;
+    /// The stored data within the op.
+    type StoredData;
+    /// Transform the stored data and the cqe into the final output.
+    fn transform_oneshot_output(self, data: Self::StoredData, cqe: cqueue::Entry) -> Self::Output;
+}
 
 /// In-flight operation
 pub(crate) struct Op<T: 'static, CqeType = SingleCQE> {
@@ -64,7 +158,7 @@ pub(crate) enum Lifecycle {
     Ignored(Box<dyn std::any::Any>),
 
     /// The operation has completed with a single cqe result
-    Completed(CqeResult),
+    Completed(cqueue::Entry),
 
     /// One or more completion results have been recieved
     /// This holds the indices uniquely identifying the list within the slab
@@ -156,14 +250,18 @@ impl<T, CqeType> Drop for Op<T, CqeType> {
 }
 
 impl Lifecycle {
-    pub(crate) fn complete(&mut self, completions: &mut Slab<Completion>, cqe: CqeResult) -> bool {
+    pub(crate) fn complete(
+        &mut self,
+        completions: &mut Slab<Completion>,
+        cqe: cqueue::Entry,
+    ) -> bool {
         use std::mem;
 
         match mem::replace(self, Lifecycle::Submitted) {
             x @ Lifecycle::Submitted | x @ Lifecycle::Waiting(..) => {
-                if io_uring::cqueue::more(cqe.flags) {
+                if io_uring::cqueue::more(cqe.flags()) {
                     let mut list = SlabListIndices::new().into_list(completions);
-                    list.push(cqe);
+                    list.push(cqe.into());
                     *self = Lifecycle::CompletionList(list.into_indices());
                 } else {
                     *self = Lifecycle::Completed(cqe);
@@ -177,7 +275,7 @@ impl Lifecycle {
             }
 
             lifecycle @ Lifecycle::Ignored(..) => {
-                if io_uring::cqueue::more(cqe.flags) {
+                if io_uring::cqueue::more(cqe.flags()) {
                     // Not yet complete. The Op has been dropped, so we can drop the CQE
                     // but we must keep the lifecycle alive until no more CQE's expected
                     *self = lifecycle;
@@ -200,7 +298,7 @@ impl Lifecycle {
                 // A completion list may contain CQE's with and without `more` flag set.
                 // Only the final one may have `more` unset, although we don't check.
                 let mut list = indices.into_list(completions);
-                list.push(cqe);
+                list.push(cqe.into());
                 *self = Lifecycle::CompletionList(list.into_indices());
                 false
             }

--- a/tests/driver.rs
+++ b/tests/driver.rs
@@ -83,7 +83,11 @@ fn too_many_submissions() {
         let file = File::create(tempfile.path()).await.unwrap();
         for _ in 0..600 {
             poll_once(async {
-                file.write_at(b"hello world".to_vec(), 0).await.0.unwrap();
+                file.write_at(b"hello world".to_vec(), 0)
+                    .submit()
+                    .await
+                    .0
+                    .unwrap();
             })
             .await;
         }

--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -60,7 +60,7 @@ fn basic_write() {
 
         let file = File::create(tempfile.path()).await.unwrap();
 
-        file.write_at(HELLO, 0).await.0.unwrap();
+        file.write_at(HELLO, 0).submit().await.0.unwrap();
 
         let file = std::fs::read(tempfile.path()).unwrap();
         assert_eq!(file, HELLO);
@@ -155,7 +155,7 @@ fn drop_open() {
         // Do something else
         let file = File::create(tempfile.path()).await.unwrap();
 
-        file.write_at(HELLO, 0).await.0.unwrap();
+        file.write_at(HELLO, 0).submit().await.0.unwrap();
 
         let file = std::fs::read(tempfile.path()).unwrap();
         assert_eq!(file, HELLO);
@@ -183,7 +183,7 @@ fn sync_doesnt_kill_anything() {
         let file = File::create(tempfile.path()).await.unwrap();
         file.sync_all().await.unwrap();
         file.sync_data().await.unwrap();
-        file.write_at(&b"foo"[..], 0).await.0.unwrap();
+        file.write_at(&b"foo"[..], 0).submit().await.0.unwrap();
         file.sync_all().await.unwrap();
         file.sync_data().await.unwrap();
     });


### PR DESCRIPTION
This change adds a new API for creating and submitting oneshot operations. This new API is intended to obsolete the existing system, however transferring over has been left out of this PR to keep the change small.

It is intended that a similar API for multishot operations be landed in a followup PR as well. This was also left out of this PR to keep the change small.

This refactoring paves the way for further work on SQE linking, multishot operations, and other improvements and additions.

The goal of this change is to allow us to split up the oneshot and multishot logic to allow for a cleaner and more extensible system, allow for user-provided operations, and allow users to control when and how their ops get submitted to the squeue.