### PR TITLE
op options: fixed file table slots

### DIFF
--- a/src/fs/open_options.rs
+++ b/src/fs/open_options.rs
@@ -62,6 +62,7 @@ pub struct OpenOptions {
     truncate: bool,
     create: bool,
     create_new: bool,
+    pub(crate) fixed_file_auto_select: bool,
     pub(crate) mode: libc::mode_t,
     pub(crate) custom_flags: libc::c_int,
 }
@@ -95,6 +96,7 @@ impl OpenOptions {
             truncate: false,
             create: false,
             create_new: false,
+            fixed_file_auto_select: false,
             mode: 0o666,
             custom_flags: 0,
         }
@@ -214,6 +216,40 @@ impl OpenOptions {
     /// ```
     pub fn truncate(&mut self, truncate: bool) -> &mut OpenOptions {
         self.truncate = truncate;
+        self
+    }
+
+    /// Sets the option for using the io_uring fixed file table to manage
+    /// the file descriptor, rather than the kernel's process file descriptor table.
+    ///
+    /// The regular file descriptor, often referred to as the raw fd,
+    /// will not be available.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_uring::fs::OpenOptions;
+    ///
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     tokio_uring::start(async {
+    ///         let file = OpenOptions::new()
+    ///             .write(true)
+    ///             .truncate(true)
+    ///             .fixed_file_auto_select(true)
+    ///             .open("foo.txt")
+    ///             .await?;
+    ///
+    ///         // Write to file. And then close.
+    ///
+    ///         // Close, returning close result.
+    ///         file.close().await?;
+    ///         Ok(())
+    ///     })
+    ///
+    /// }
+    /// ```
+    pub fn fixed_file_auto_select(&mut self, fixed_file_auto_select: bool) -> &mut OpenOptions {
+        self.fixed_file_auto_select = fixed_file_auto_select;
         self
     }
 

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -2,6 +2,7 @@ use crate::buf::BoundedBufMut;
 use crate::io::SharedFd;
 use crate::BufResult;
 
+use crate::io::shared_fd::CommonFd;
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
 use std::io;
@@ -30,9 +31,20 @@ impl<T: BoundedBufMut> Op<Read<T>> {
                     // Get raw buffer info
                     let ptr = read.buf.stable_mut_ptr();
                     let len = read.buf.bytes_total();
-                    opcode::Read::new(types::Fd(fd.raw_fd()), ptr, len as _)
-                        .offset(offset as _)
-                        .build()
+                    match read.fd.common_fd() {
+                        CommonFd::Raw(raw) => {
+                            let fd = types::Fd(raw);
+                            opcode::Read::new(fd, ptr, len as _)
+                                .offset(offset as _)
+                                .build()
+                        }
+                        CommonFd::Fixed(fixed) => {
+                            let fd = types::Fixed(fixed);
+                            opcode::Read::new(fd, ptr, len as _)
+                                .offset(offset as _)
+                                .build()
+                        }
+                    }
                 },
             )
         })

--- a/src/io/write.rs
+++ b/src/io/write.rs
@@ -1,7 +1,10 @@
-use crate::{buf::BoundedBuf, io::SharedFd, BufResult, OneshotOutputTransform, UnsubmittedOneshot};
+use crate::{
+    buf::BoundedBuf,
+    io::{shared_fd::CommonFd, SharedFd},
+    BufResult, OneshotOutputTransform, UnsubmittedOneshot,
+};
 use io_uring::cqueue::Entry;
-use std::io;
-use std::marker::PhantomData;
+use std::{io, marker::PhantomData};
 
 /// An unsubmitted write operation.
 pub type UnsubmittedWrite<T> = UnsubmittedOneshot<WriteData<T>, WriteTransform<T>>;
@@ -51,9 +54,20 @@ impl<T: BoundedBuf> UnsubmittedWrite<T> {
             WriteTransform {
                 _phantom: PhantomData::default(),
             },
-            opcode::Write::new(types::Fd(fd.raw_fd()), ptr, len as _)
-                .offset(offset as _)
-                .build(),
+            match fd.common_fd() {
+                CommonFd::Raw(raw) => {
+                    let fd = types::Fd(raw);
+                    opcode::Write::new(fd, ptr, len as _)
+                        .offset(offset as _)
+                        .build()
+                }
+                CommonFd::Fixed(fixed) => {
+                    let fd = types::Fixed(fixed);
+                    opcode::Write::new(fd, ptr, len as _)
+                        .offset(offset as _)
+                        .build()
+                }
+            },
         )
     }
 }


### PR DESCRIPTION
Introduces the `fixed_file_auto_select` option to the fs::OpenOptions.

And modifies `read`, `write` and `close` to use the newly introduced fixed_file variation of a SharedFd.