### PR TITLE
chore: replace futures dependency with futures_util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2.80"
 io-uring = "0.5.13"
 socket2 = { version = "0.4.4", features = ["all"] }
 bytes = { version = "1.0", optional = true }
-futures = "0.3.26"
+futures-util = { version = "0.3.26", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/fs/create_dir_all.rs
+++ b/src/fs/create_dir_all.rs
@@ -1,4 +1,4 @@
-use futures::future::LocalBoxFuture;
+use futures_util::future::LocalBoxFuture;
 use std::io;
 use std::path::Path;
 


### PR DESCRIPTION
Removes loads of dependencies for dependant libraries.