### PR TITLE
Update `BufResult<T, B>` to be `Result<(T,B), BufError<B>>`

### DIFF
--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -29,8 +29,7 @@ fn main() {
 
         loop {
             // Read a chunk
-            let (res, b) = file.read_at(buf, pos).await;
-            let n = res.unwrap();
+            let (n, b) = file.read_at(buf, pos).await.unwrap();
 
             if n == 0 {
                 break;

--- a/examples/mix.rs
+++ b/examples/mix.rs
@@ -34,15 +34,14 @@ fn main() {
 
                 loop {
                     // Read a chunk
-                    let (res, b) = file.read_at(buf, pos).await;
-                    let n = res.unwrap();
+                    let (n, b) = file.read_at(buf, pos).await.unwrap();
 
                     if n == 0 {
                         break;
                     }
 
-                    let (res, b) = socket.write(b).submit().await;
-                    pos += res.unwrap() as u64;
+                    let (written, b) = socket.write(b).submit().await.unwrap();
+                    pos += written as u64;
 
                     buf = b;
                 }

--- a/examples/tcp_listener.rs
+++ b/examples/tcp_listener.rs
@@ -29,16 +29,14 @@ fn main() {
 
                 let mut buf = vec![0u8; 4096];
                 loop {
-                    let (result, nbuf) = stream.read(buf).await;
+                    let (read, nbuf) = stream.read(buf).await.unwrap();
                     buf = nbuf;
-                    let read = result.unwrap();
                     if read == 0 {
                         println!("{} closed, {} total ping-ponged", socket_addr, n);
                         break;
                     }
 
-                    let (res, slice) = stream.write_all(buf.slice(..read)).await;
-                    let _ = res.unwrap();
+                    let (_, slice) = stream.write_all(buf.slice(..read)).await.unwrap();
                     buf = slice.into_inner();
                     println!("{} all {} bytes ping-ponged", socket_addr, read);
                     n += read;

--- a/examples/tcp_listener_fixed_buffers.rs
+++ b/examples/tcp_listener_fixed_buffers.rs
@@ -79,17 +79,15 @@ async fn echo_handler<T: IoBufMut>(
         // Each time through the loop, use fbuf and then get it back for the next
         // iteration.
 
-        let (result, fbuf1) = stream.read_fixed(fbuf).await;
+        let (read, fbuf1) = stream.read_fixed(fbuf).await.unwrap();
         fbuf = {
-            let read = result.unwrap();
             if read == 0 {
                 break;
             }
             assert_eq!(4096, fbuf1.len()); // To prove a point.
 
-            let (res, nslice) = stream.write_fixed_all(fbuf1.slice(..read)).await;
+            let (_, nslice) = stream.write_fixed_all(fbuf1.slice(..read)).await.unwrap();
 
-            let _ = res.unwrap();
             println!("peer {} all {} bytes ping-ponged", peer, read);
             n += read;
 

--- a/examples/tcp_stream.rs
+++ b/examples/tcp_stream.rs
@@ -15,11 +15,10 @@ fn main() {
         let stream = TcpStream::connect(socket_addr).await.unwrap();
         let buf = vec![1u8; 128];
 
-        let (result, buf) = stream.write(buf).submit().await;
-        println!("written: {}", result.unwrap());
+        let (written, buf) = stream.write(buf).submit().await.unwrap();
+        println!("written: {}", written);
 
-        let (result, buf) = stream.read(buf).await;
-        let read = result.unwrap();
+        let (read, buf) = stream.read(buf).await.unwrap();
         println!("read: {:?}", &buf[..read]);
     });
 }

--- a/examples/udp_socket.rs
+++ b/examples/udp_socket.rs
@@ -15,12 +15,11 @@ fn main() {
 
         let buf = vec![0u8; 128];
 
-        let (result, mut buf) = socket.recv_from(buf).await;
-        let (read, socket_addr) = result.unwrap();
+        let ((read, socket_addr), mut buf) = socket.recv_from(buf).await.unwrap();
         buf.resize(read, 0);
         println!("received from {}: {:?}", socket_addr, &buf[..]);
 
-        let (result, _buf) = socket.send_to(buf, socket_addr).await;
-        println!("sent to {}: {}", socket_addr, result.unwrap());
+        let (sent, _buf) = socket.send_to(buf, socket_addr).await.unwrap();
+        println!("sent to {}: {}", socket_addr, sent);
     });
 }

--- a/examples/unix_listener.rs
+++ b/examples/unix_listener.rs
@@ -20,11 +20,10 @@ fn main() {
             tokio_uring::spawn(async move {
                 let buf = vec![1u8; 128];
 
-                let (result, buf) = stream.write(buf).submit().await;
-                println!("written to {}: {}", &socket_addr, result.unwrap());
+                let (written, buf) = stream.write(buf).submit().await.unwrap();
+                println!("written to {}: {}", &socket_addr, written);
 
-                let (result, buf) = stream.read(buf).await;
-                let read = result.unwrap();
+                let (read, buf) = stream.read(buf).await.unwrap();
                 println!("read from {}: {:?}", &socket_addr, &buf[..read]);
             });
         }

--- a/examples/unix_stream.rs
+++ b/examples/unix_stream.rs
@@ -15,11 +15,10 @@ fn main() {
         let stream = UnixStream::connect(socket_addr).await.unwrap();
         let buf = vec![1u8; 128];
 
-        let (result, buf) = stream.write(buf).submit().await;
-        println!("written: {}", result.unwrap());
+        let (written, buf) = stream.write(buf).submit().await.unwrap();
+        println!("written: {}", written);
 
-        let (result, buf) = stream.read(buf).await;
-        let read = result.unwrap();
+        let (read, buf) = stream.read(buf).await.unwrap();
         println!("read: {:?}", &buf[..read]);
     });
 }

--- a/examples/wrk-bench.rs
+++ b/examples/wrk-bench.rs
@@ -21,10 +21,10 @@ fn main() -> io::Result<()> {
                     let (stream, _) = listener.accept().await?;
 
                     tokio_uring::spawn(async move {
-                        let (result, _) = stream.write(RESPONSE).submit().await;
+                        let result = stream.write(RESPONSE).submit().await;
 
                         if let Err(err) = result {
-                            eprintln!("Client connection failed: {}", err);
+                            eprintln!("Client connection failed: {}", err.0);
                         }
                     });
                 }

--- a/src/buf/slice.rs
+++ b/src/buf/slice.rs
@@ -23,6 +23,7 @@ use std::ops;
 ///
 /// assert_eq!(&slice[..], b"hello");
 /// ```
+#[derive(Debug)]
 pub struct Slice<T> {
     buf: T,
     begin: usize,

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -1,6 +1,6 @@
 use crate::buf::BoundedBufMut;
 use crate::io::SharedFd;
-use crate::BufResult;
+use crate::{BufError, BufResult};
 
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
@@ -59,6 +59,9 @@ where
             }
         }
 
-        (res, buf)
+        match res {
+            Ok(n) => Ok((n, buf)),
+            Err(e) => Err(BufError(e, buf)),
+        }
     }
 }

--- a/src/io/read_fixed.rs
+++ b/src/io/read_fixed.rs
@@ -2,7 +2,7 @@ use crate::buf::fixed::FixedBuf;
 use crate::buf::BoundedBufMut;
 use crate::io::SharedFd;
 use crate::runtime::driver::op::{self, Completable, Op};
-use crate::BufResult;
+use crate::{BufError, BufResult};
 
 use crate::runtime::CONTEXT;
 use std::io;
@@ -68,6 +68,9 @@ where
             }
         }
 
-        (res, buf)
+        match res {
+            Ok(n) => Ok((n, buf)),
+            Err(e) => Err(BufError(e, buf)),
+        }
     }
 }

--- a/src/io/readv.rs
+++ b/src/io/readv.rs
@@ -1,5 +1,5 @@
 use crate::buf::BoundedBufMut;
-use crate::BufResult;
+use crate::{BufError, BufResult};
 
 use crate::io::SharedFd;
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
@@ -87,6 +87,9 @@ where
             assert_eq!(count, 0);
         }
 
-        (res, bufs)
+        match res {
+            Ok(n) => Ok((n, bufs)),
+            Err(e) => Err(BufError(e, bufs)),
+        }
     }
 }

--- a/src/io/recv_from.rs
+++ b/src/io/recv_from.rs
@@ -1,5 +1,6 @@
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
+use crate::BufError;
 use crate::{buf::BoundedBufMut, io::SharedFd, BufResult};
 use socket2::SockAddr;
 use std::{
@@ -78,6 +79,9 @@ where
             (n, socket_addr)
         });
 
-        (res, buf)
+        match res {
+            Ok(n) => Ok((n, buf)),
+            Err(e) => Err(BufError(e, buf)),
+        }
     }
 }

--- a/src/io/recvmsg.rs
+++ b/src/io/recvmsg.rs
@@ -1,5 +1,6 @@
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
+use crate::BufError;
 use crate::{buf::BoundedBufMut, io::SharedFd, BufResult};
 use socket2::SockAddr;
 use std::{
@@ -92,6 +93,9 @@ where
             (n, socket_addr)
         });
 
-        (res, bufs)
+        match res {
+            Ok(n) => Ok((n, bufs)),
+            Err(e) => Err(BufError(e, bufs)),
+        }
     }
 }

--- a/src/io/send_to.rs
+++ b/src/io/send_to.rs
@@ -2,7 +2,7 @@ use crate::buf::BoundedBuf;
 use crate::io::SharedFd;
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
-use crate::BufResult;
+use crate::{BufError, BufResult};
 use socket2::SockAddr;
 use std::io::IoSlice;
 use std::{boxed::Box, io, net::SocketAddr};
@@ -78,6 +78,9 @@ impl<T> Completable for SendTo<T> {
         // Recover the buffer
         let buf = self.buf;
 
-        (res, buf)
+        match res {
+            Ok(n) => Ok((n, buf)),
+            Err(e) => Err(BufError(e, buf)),
+        }
     }
 }

--- a/src/io/send_zc.rs
+++ b/src/io/send_zc.rs
@@ -1,5 +1,6 @@
 use crate::runtime::driver::op::{Completable, CqeResult, MultiCQEFuture, Op, Updateable};
 use crate::runtime::CONTEXT;
+use crate::BufError;
 use crate::{buf::BoundedBuf, io::SharedFd, BufResult};
 use std::io;
 
@@ -46,7 +47,11 @@ impl<T> Completable for SendZc<T> {
         let res = cqe.result.map(|v| self.bytes + v as usize);
         // Recover the buffer
         let buf = self.buf;
-        (res, buf)
+
+        match res {
+            Ok(n) => Ok((n, buf)),
+            Err(e) => Err(BufError(e, buf)),
+        }
     }
 }
 

--- a/src/io/write.rs
+++ b/src/io/write.rs
@@ -1,3 +1,4 @@
+use crate::BufError;
 use crate::{buf::BoundedBuf, io::SharedFd, BufResult, OneshotOutputTransform, UnsubmittedOneshot};
 use io_uring::cqueue::Entry;
 use std::io;
@@ -31,7 +32,10 @@ impl<T> OneshotOutputTransform for WriteTransform<T> {
             Err(io::Error::from_raw_os_error(-cqe.result()))
         };
 
-        (res, data.buf)
+        match res {
+            Ok(n) => Ok((n, data.buf)),
+            Err(e) => Err(BufError(e, data.buf)),
+        }
     }
 }
 

--- a/src/io/write_fixed.rs
+++ b/src/io/write_fixed.rs
@@ -2,7 +2,7 @@ use crate::buf::fixed::FixedBuf;
 use crate::buf::BoundedBuf;
 use crate::io::SharedFd;
 use crate::runtime::driver::op::{self, Completable, Op};
-use crate::BufResult;
+use crate::{BufResult, BufError};
 
 use crate::runtime::CONTEXT;
 use std::io;
@@ -56,6 +56,9 @@ impl<T> Completable for WriteFixed<T> {
         // Recover the buffer
         let buf = self.buf;
 
-        (res, buf)
+        match res {
+            Ok(n) => Ok((n, buf)),
+            Err(e) => Err(BufError(e, buf)),
+        }
     }
 }

--- a/src/io/write_fixed.rs
+++ b/src/io/write_fixed.rs
@@ -2,7 +2,7 @@ use crate::buf::fixed::FixedBuf;
 use crate::buf::BoundedBuf;
 use crate::io::SharedFd;
 use crate::runtime::driver::op::{self, Completable, Op};
-use crate::{BufResult, BufError};
+use crate::{BufError, BufResult};
 
 use crate::runtime::CONTEXT;
 use std::io;

--- a/src/io/writev.rs
+++ b/src/io/writev.rs
@@ -1,3 +1,4 @@
+use crate::BufError;
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
 use crate::{buf::BoundedBuf, io::SharedFd, BufResult};
@@ -66,6 +67,9 @@ where
         // Recover the buffer
         let buf = self.bufs;
 
-        (res, buf)
+        match res {
+            Ok(n) => Ok((n, buf)),
+            Err(e) => Err(BufError(e, buf)),
+        }
     }
 }

--- a/src/io/writev.rs
+++ b/src/io/writev.rs
@@ -1,6 +1,6 @@
-use crate::BufError;
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
+use crate::BufError;
 use crate::{buf::BoundedBuf, io::SharedFd, BufResult};
 use libc::iovec;
 use std::io;

--- a/src/io/writev_all.rs
+++ b/src/io/writev_all.rs
@@ -1,6 +1,6 @@
-use crate::BufError;
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
+use crate::BufError;
 use crate::{buf::BoundedBuf, io::SharedFd};
 use libc::iovec;
 use std::io;

--- a/src/io/writev_all.rs
+++ b/src/io/writev_all.rs
@@ -1,3 +1,4 @@
+use crate::BufError;
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
 use crate::{buf::BoundedBuf, io::SharedFd};
@@ -59,7 +60,7 @@ pub(crate) async fn writev_at_all<T: BoundedBuf>(
 
             // On error, there is no indication how many bytes were written. This is standard.
             // The device doesn't tell us that either.
-            Err(e) => return (Err(e), bufs),
+            Err(e) => return Err(BufError(e, bufs)),
         };
 
         // TODO if n is zero, while there was more data to be written, should this be interpreted
@@ -101,7 +102,7 @@ pub(crate) async fn writev_at_all<T: BoundedBuf>(
             break;
         }
     }
-    (Ok(total), bufs)
+    Ok((total, bufs))
 }
 
 struct WritevAll<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,6 @@ impl Builder {
 /// ```
 pub type BufResult<T, B> = std::result::Result<(T, B), BufError<B>>;
 
-
 /// A specialized `Error` type for `io-uring` operations with buffers.
 #[derive(Debug)]
 pub struct BufError<B>(pub std::io::Error, pub B);

--- a/tests/driver.rs
+++ b/tests/driver.rs
@@ -10,6 +10,7 @@ mod future;
 fn complete_ops_on_drop() {
     use std::sync::Arc;
 
+    #[derive(Debug)]
     struct MyBuf {
         data: Vec<u8>,
         _ref_cnt: Arc<()>,
@@ -59,7 +60,6 @@ fn complete_ops_on_drop() {
                 25 * 1024 * 1024,
             )
             .await
-            .0
             .unwrap();
         })
         .await;
@@ -86,7 +86,6 @@ fn too_many_submissions() {
                 file.write_at(b"hello world".to_vec(), 0)
                     .submit()
                     .await
-                    .0
                     .unwrap();
             })
             .await;

--- a/tests/fixed_buf.rs
+++ b/tests/fixed_buf.rs
@@ -42,8 +42,7 @@ fn fixed_buf_turnaround() {
         // for another instance.
         assert!(buffers.check_out(0).is_none());
 
-        let (res, buf) = op.await;
-        let n = res.unwrap();
+        let (n, buf) = op.await.unwrap();
         assert_eq!(n, HELLO.len());
 
         // The buffer is owned by `buf`, can't check it out
@@ -81,12 +80,11 @@ fn unregister_invalidates_checked_out_buffers() {
         // The old buffer's index no longer matches the memory area of the
         // currently registered buffer, so the read operation using the old
         // buffer's memory should fail.
-        let (res, _) = file.read_fixed_at(fixed_buf, 0).await;
+        let res = file.read_fixed_at(fixed_buf, 0).await;
         assert_err!(res);
 
         let fixed_buf = buffers.check_out(0).unwrap();
-        let (res, buf) = file.read_fixed_at(fixed_buf, 0).await;
-        let n = res.unwrap();
+        let (n, buf) = file.read_fixed_at(fixed_buf, 0).await.unwrap();
         assert_eq!(n, HELLO.len());
         assert_eq!(&buf[..], HELLO);
     });
@@ -112,18 +110,16 @@ fn slicing() {
         let fixed_buf = buffers.check_out(0).unwrap();
 
         // Read no more than 8 bytes into the fixed buffer.
-        let (res, slice) = file.read_fixed_at(fixed_buf.slice(..8), 3).await;
-        let n = res.unwrap();
+        let (n, slice) = file.read_fixed_at(fixed_buf.slice(..8), 3).await.unwrap();
         assert_eq!(n, 8);
         assert_eq!(slice[..], HELLO[3..11]);
         let fixed_buf = slice.into_inner();
 
         // Write from the fixed buffer, starting at offset 1,
         // up to the end of the initialized bytes in the buffer.
-        let (res, slice) = file
+        let (n, slice) = file
             .write_fixed_at(fixed_buf.slice(1..), HELLO.len() as u64)
-            .await;
-        let n = res.unwrap();
+            .await.unwrap();
         assert_eq!(n, 7);
         assert_eq!(slice[..], HELLO[4..11]);
         let fixed_buf = slice.into_inner();
@@ -131,8 +127,7 @@ fn slicing() {
         // Read into the fixed buffer, overwriting bytes starting from offset 3
         // and then extending the initialized part with as many bytes as
         // the operation can read.
-        let (res, slice) = file.read_fixed_at(fixed_buf.slice(3..), 0).await;
-        let n = res.unwrap();
+        let (n, slice) = file.read_fixed_at(fixed_buf.slice(3..), 0).await.unwrap();
         assert_eq!(n, HELLO.len() + 7);
         assert_eq!(slice[..HELLO.len()], HELLO[..]);
         assert_eq!(slice[HELLO.len()..], HELLO[4..11]);
@@ -167,8 +162,7 @@ fn pool_next_as_concurrency_limit() {
                 let file = File::from_std(cloned_file);
                 let data = [b'0' + i as u8; BUF_SIZE];
                 buf.put_slice(&data);
-                let (res, buf) = file.write_fixed_all_at(buf, BUF_SIZE as u64 * i).await;
-                res.unwrap();
+                let (_, buf) = file.write_fixed_all_at(buf, BUF_SIZE as u64 * i).await.unwrap();
                 println!("[worker {}]: dropping buffer {}", i, buf.buf_index());
             });
 

--- a/tests/fixed_buf.rs
+++ b/tests/fixed_buf.rs
@@ -119,7 +119,8 @@ fn slicing() {
         // up to the end of the initialized bytes in the buffer.
         let (n, slice) = file
             .write_fixed_at(fixed_buf.slice(1..), HELLO.len() as u64)
-            .await.unwrap();
+            .await
+            .unwrap();
         assert_eq!(n, 7);
         assert_eq!(slice[..], HELLO[4..11]);
         let fixed_buf = slice.into_inner();
@@ -162,7 +163,10 @@ fn pool_next_as_concurrency_limit() {
                 let file = File::from_std(cloned_file);
                 let data = [b'0' + i as u8; BUF_SIZE];
                 buf.put_slice(&data);
-                let (_, buf) = file.write_fixed_all_at(buf, BUF_SIZE as u64 * i).await.unwrap();
+                let (_, buf) = file
+                    .write_fixed_all_at(buf, BUF_SIZE as u64 * i)
+                    .await
+                    .unwrap();
                 println!("[worker {}]: dropping buffer {}", i, buf.buf_index());
             });
 

--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -19,8 +19,7 @@ const HELLO: &[u8] = b"hello world...";
 
 async fn read_hello(file: &File) {
     let buf = Vec::with_capacity(1024);
-    let (res, buf) = file.read_at(buf, 0).await;
-    let n = res.unwrap();
+    let (n, buf) = file.read_at(buf, 0).await.unwrap();
 
     assert_eq!(n, HELLO.len());
     assert_eq!(&buf[..n], HELLO);
@@ -47,8 +46,7 @@ fn basic_read_exact() {
         tempfile.write_all(&data).unwrap();
 
         let file = File::open(tempfile.path()).await.unwrap();
-        let (res, buf) = file.read_exact_at(buf, 0).await;
-        res.unwrap();
+        let (_, buf) = file.read_exact_at(buf, 0).await.unwrap();
         assert_eq!(buf, data);
     });
 }
@@ -60,7 +58,7 @@ fn basic_write() {
 
         let file = File::create(tempfile.path()).await.unwrap();
 
-        file.write_at(HELLO, 0).submit().await.0.unwrap();
+        file.write_at(HELLO, 0).submit().await.unwrap();
 
         let file = std::fs::read(tempfile.path()).unwrap();
         assert_eq!(file, HELLO);
@@ -75,8 +73,7 @@ fn vectored_read() {
 
         let file = File::open(tempfile.path()).await.unwrap();
         let bufs = vec![Vec::<u8>::with_capacity(5), Vec::<u8>::with_capacity(9)];
-        let (res, bufs) = file.readv_at(bufs, 0).await;
-        let n = res.unwrap();
+        let (n, bufs) = file.readv_at(bufs, 0).await.unwrap();
 
         assert_eq!(n, HELLO.len());
         assert_eq!(bufs[1][0], b' ');
@@ -93,7 +90,7 @@ fn vectored_write() {
         let buf2 = " world...".to_owned().into_bytes();
         let bufs = vec![buf1, buf2];
 
-        file.writev_at(bufs, 0).await.0.unwrap();
+        file.writev_at(bufs, 0).await.unwrap();
 
         let file = std::fs::read(tempfile.path()).unwrap();
         assert_eq!(file, HELLO);
@@ -108,8 +105,7 @@ fn basic_write_all() {
         let tempfile = tempfile();
 
         let file = File::create(tempfile.path()).await.unwrap();
-        let (ret, data) = file.write_all_at(data, 0).await;
-        ret.unwrap();
+        let (_, data) = file.write_all_at(data, 0).await.unwrap();
 
         let file = std::fs::read(tempfile.path()).unwrap();
         assert_eq!(file, data);
@@ -155,7 +151,7 @@ fn drop_open() {
         // Do something else
         let file = File::create(tempfile.path()).await.unwrap();
 
-        file.write_at(HELLO, 0).submit().await.0.unwrap();
+        file.write_at(HELLO, 0).submit().await.unwrap();
 
         let file = std::fs::read(tempfile.path()).unwrap();
         assert_eq!(file, HELLO);
@@ -183,7 +179,7 @@ fn sync_doesnt_kill_anything() {
         let file = File::create(tempfile.path()).await.unwrap();
         file.sync_all().await.unwrap();
         file.sync_data().await.unwrap();
-        file.write_at(&b"foo"[..], 0).submit().await.0.unwrap();
+        file.write_at(&b"foo"[..], 0).submit().await.unwrap();
         file.sync_all().await.unwrap();
         file.sync_data().await.unwrap();
     });
@@ -236,16 +232,14 @@ fn read_fixed() {
 
         let fixed_buf = buffers.check_out(0).unwrap();
         assert_eq!(fixed_buf.bytes_total(), 6);
-        let (res, buf) = file.read_fixed_at(fixed_buf.slice(..), 0).await;
-        let n = res.unwrap();
+        let (n, buf) = file.read_fixed_at(fixed_buf.slice(..), 0).await.unwrap();
 
         assert_eq!(n, 6);
         assert_eq!(&buf[..], &HELLO[..6]);
 
         let fixed_buf = buffers.check_out(1).unwrap();
         assert_eq!(fixed_buf.bytes_total(), 1024);
-        let (res, buf) = file.read_fixed_at(fixed_buf.slice(..), 6).await;
-        let n = res.unwrap();
+        let (n, buf) = file.read_fixed_at(fixed_buf.slice(..), 6).await.unwrap();
 
         assert_eq!(n, HELLO.len() - 6);
         assert_eq!(&buf[..], &HELLO[6..]);
@@ -266,16 +260,14 @@ fn write_fixed() {
         let mut buf = fixed_buf;
         buf.put_slice(&HELLO[..6]);
 
-        let (res, _) = file.write_fixed_at(buf, 0).await;
-        let n = res.unwrap();
+        let (n, _) = file.write_fixed_at(buf, 0).await.unwrap();
         assert_eq!(n, 6);
 
         let fixed_buf = buffers.check_out(1).unwrap();
         let mut buf = fixed_buf;
         buf.put_slice(&HELLO[6..]);
 
-        let (res, _) = file.write_fixed_at(buf, 6).await;
-        let n = res.unwrap();
+        let (n, _) = file.write_fixed_at(buf, 6).await.unwrap();
         assert_eq!(n, HELLO.len() - 6);
 
         let file = std::fs::read(tempfile.path()).unwrap();


### PR DESCRIPTION
# Why? 

Solves https://github.com/tokio-rs/tokio-uring/issues/178

# How? 

I've changed the type to be what was proposed in the issue and then followed the compiler warnings to make rustc happy. 

I've also added a free function `map_buf` which allows to map a function over the buffer on `BufResult`. Let me know if that's okay, but it made writing some code easier. 