### PR TITLE
Add `msg_control` access for `UdpSocket::recvmsg`.

### DIFF
--- a/src/io/socket.rs
+++ b/src/io/socket.rs
@@ -189,11 +189,12 @@ impl Socket {
         op.await
     }
 
-    pub(crate) async fn recvmsg<T: BoundedBufMut>(
+    pub(crate) async fn recvmsg<T: BoundedBufMut, U: BoundedBufMut>(
         &self,
         buf: Vec<T>,
-    ) -> crate::BufResult<(usize, SocketAddr), Vec<T>> {
-        let op = Op::recvmsg(&self.fd, buf).unwrap();
+        msg_control: Option<U>,
+    ) -> crate::BufResult<(usize, SocketAddr, Option<U>), Vec<T>> {
+        let op = Op::recvmsg(&self.fd, buf, msg_control).unwrap();
         op.await
     }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -305,12 +305,14 @@ impl UdpSocket {
 
     /// Receives a single datagram message on the socket, into multiple buffers
     ///
-    /// On success, returns the number of bytes read and the origin.
-    pub async fn recvmsg<T: BoundedBufMut>(
+    /// On success, returns the number of bytes read, the origin, and the msg_control, as modified
+    /// by the kernel.
+    pub async fn recvmsg<T: BoundedBufMut, U: BoundedBufMut>(
         &self,
         buf: Vec<T>,
-    ) -> crate::BufResult<(usize, SocketAddr), Vec<T>> {
-        self.inner.recvmsg(buf).await
+        msg_control: Option<U>,
+    ) -> crate::BufResult<(usize, SocketAddr, Option<U>), Vec<T>> {
+        self.inner.recvmsg(buf, msg_control).await
     }
 
     /// Reads a packet of data from the socket into the buffer.


### PR DESCRIPTION
Closes #274.
The parameter is optional, so this is an opt-in change. However, it changes the public facing API.
I can add another public facing function with this functionality while keeping the old API, if you'd like :)