### PR TITLE
Add mmap-support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ libc = "0.2.80"
 io-uring = "0.6.0"
 socket2 = { version = "0.4.4", features = ["all"] }
 bytes = { version = "1.0", optional = true }
+memmap2 = { version = "0.9.0", optional = true }
 futures-util = { version = "0.3.26", default-features = false, features = ["std"] }
 
 [dev-dependencies]
@@ -33,6 +34,12 @@ criterion = "0.4.0"
 # we use joinset in our tests
 tokio = "1.21.2"
 nix = "0.26.1"
+
+[features]
+default = ["bytes", "mmap"]
+mmap  = ["dep:memmap2"]
+bytes = ["dep:bytes"]
+
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/buf/io_buf.rs
+++ b/src/buf/io_buf.rs
@@ -110,3 +110,33 @@ unsafe impl IoBuf for bytes::BytesMut {
         self.capacity()
     }
 }
+
+#[cfg(feature = "mmap")]
+unsafe impl IoBuf for memmap2::Mmap {
+    fn stable_ptr(&self) -> *const u8 {
+        self.as_ptr()
+    }
+
+    fn bytes_init(&self) -> usize {
+        self.len()
+    }
+
+    fn bytes_total(&self) -> usize {
+        self.len()
+    }
+}
+
+#[cfg(feature = "mmap")]
+unsafe impl IoBuf for memmap2::MmapMut {
+    fn stable_ptr(&self) -> *const u8 {
+        self.as_ptr()
+    }
+
+    fn bytes_init(&self) -> usize {
+        self.len()
+    }
+
+    fn bytes_total(&self) -> usize {
+        self.len()
+    }
+}

--- a/src/buf/io_buf_mut.rs
+++ b/src/buf/io_buf_mut.rs
@@ -58,3 +58,14 @@ unsafe impl IoBufMut for bytes::BytesMut {
         }
     }
 }
+
+#[cfg(feature = "mmap")]
+unsafe impl IoBufMut for memmap2::MmapMut {
+    fn stable_mut_ptr(&mut self) -> *mut u8 {
+        self.as_mut_ptr()
+    }
+
+    unsafe fn set_init(&mut self, _init_len: usize) {
+        // Memory is zero initialised
+    }
+}


### PR DESCRIPTION
Adds a feature which provides IoBuf and IoBufMut for `memmap2::Mmap` and `memmap2::MmapMut`, similar to the existing `bytes` feature