### PR TITLE
chore: format let-else

### DIFF
--- a/src/buf/fixed/plumbing/registry.rs
+++ b/src/buf/fixed/plumbing/registry.rs
@@ -74,7 +74,7 @@ impl<T: IoBufMut> Registry<T> {
     pub(crate) fn check_out(&mut self, index: usize) -> Option<CheckedOutBuf> {
         let state = self.states.get_mut(index)?;
         let BufState::Free { init_len } = *state else {
-            return None
+            return None;
         };
 
         *state = BufState::CheckedOut;


### PR DESCRIPTION
This fixes CI failure https://github.com/tokio-rs/tokio-uring/actions/runs/7437161507/job/20234483955?pr=290.

rustfmt recently supported the formatting of let-else syntax, so CI did not fail before.