### PR TITLE
Add UnsubmittedRead and Link API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ io-uring = "0.6.0"
 socket2 = { version = "0.4.4", features = ["all"] }
 bytes = { version = "1.0", optional = true }
 futures-util = { version = "0.3.26", default-features = false, features = ["std"] }
+pin-project-lite = "0.2.13"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ keywords = ["async", "fs", "io-uring"]
 tokio = { version = "1.2", features = ["net", "rt", "sync"] }
 slab = "0.4.2"
 libc = "0.2.80"
-io-uring = "0.6.0"
+io-uring = { git = "https://github.com/ileixe/io-uring" }
 socket2 = { version = "0.4.4", features = ["all"] }
 bytes = { version = "1.0", optional = true }
 futures-util = { version = "0.3.26", default-features = false, features = ["std"] }

--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -29,7 +29,7 @@ fn main() {
 
         loop {
             // Read a chunk
-            let (res, b) = file.read_at(buf, pos).await;
+            let (res, b) = file.read_at(buf, pos).submit().await;
             let n = res.unwrap();
 
             if n == 0 {

--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -3,7 +3,7 @@ use std::{
     {env, io},
 };
 
-use tokio_uring::fs::File;
+use tokio_uring::{fs::File, Submit};
 
 fn main() {
     // The file to `cat` is passed as a CLI argument

--- a/examples/mix.rs
+++ b/examples/mix.rs
@@ -34,7 +34,7 @@ fn main() {
 
                 loop {
                     // Read a chunk
-                    let (res, b) = file.read_at(buf, pos).await;
+                    let (res, b) = file.read_at(buf, pos).submit().await;
                     let n = res.unwrap();
 
                     if n == 0 {

--- a/examples/mix.rs
+++ b/examples/mix.rs
@@ -4,7 +4,7 @@
 
 use std::env;
 
-use tokio_uring::{fs::File, net::TcpListener};
+use tokio_uring::{fs::File, net::TcpListener, Submit};
 
 fn main() {
     // The file to serve over TCP is passed as a CLI argument

--- a/examples/tcp_stream.rs
+++ b/examples/tcp_stream.rs
@@ -1,6 +1,6 @@
 use std::{env, net::SocketAddr};
 
-use tokio_uring::net::TcpStream;
+use tokio_uring::{net::TcpStream, Submit};
 
 fn main() {
     let args: Vec<_> = env::args().collect();

--- a/examples/unix_listener.rs
+++ b/examples/unix_listener.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use tokio_uring::net::UnixListener;
+use tokio_uring::{net::UnixListener, Submit};
 
 fn main() {
     let args: Vec<_> = env::args().collect();

--- a/examples/unix_stream.rs
+++ b/examples/unix_stream.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use tokio_uring::net::UnixStream;
+use tokio_uring::{net::UnixStream, Submit};
 
 fn main() {
     let args: Vec<_> = env::args().collect();

--- a/examples/wrk-bench.rs
+++ b/examples/wrk-bench.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::rc::Rc;
 use tokio::task::JoinHandle;
+use tokio_uring::Submit;
 
 pub const RESPONSE: &'static [u8] =
     b"HTTP/1.1 200 OK\nContent-Type: text/plain\nContent-Length: 12\n\nHello world!";

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -3,7 +3,7 @@ use crate::buf::{BoundedBuf, BoundedBufMut, IoBuf, IoBufMut, Slice};
 use crate::fs::OpenOptions;
 use crate::io::SharedFd;
 
-use crate::runtime::driver::op::Op;
+use crate::runtime::driver::op::{Op, Submit};
 use crate::{UnsubmittedOneshot, UnsubmittedRead, UnsubmittedWrite};
 use std::fmt;
 use std::io;
@@ -32,6 +32,7 @@ use std::path::Path;
 ///
 /// ```no_run
 /// use tokio_uring::fs::File;
+/// use tokio_uring::Submit;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     tokio_uring::start(async {
@@ -158,6 +159,7 @@ impl File {
     ///
     /// ```no_run
     /// use tokio_uring::fs::File;
+    /// use tokio_uring::Submit;
     ///
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     tokio_uring::start(async {
@@ -518,6 +520,7 @@ impl File {
     ///
     /// ```no_run
     /// use tokio_uring::fs::File;
+    /// use tokio_uring::Submit;
     ///
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     tokio_uring::start(async {
@@ -767,6 +770,7 @@ impl File {
     ///
     /// ```no_run
     /// use tokio_uring::fs::File;
+    /// use tokio_uring::Submit;
     ///
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     tokio_uring::start(async {
@@ -804,6 +808,7 @@ impl File {
     ///
     /// ```no_run
     /// use tokio_uring::fs::File;
+    /// use tokio_uring::Submit;
     ///
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     tokio_uring::start(async {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use noop::NoOp;
 
 mod open;
 
-mod read;
+pub(crate) mod read;
 
 mod read_fixed;
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod read;
 
 mod read_fixed;
 
-mod readv;
+pub(crate) mod readv;
 
 mod recv_from;
 
@@ -52,7 +52,7 @@ pub(crate) mod write;
 
 mod write_fixed;
 
-mod writev;
+pub(crate) mod writev;
 
 mod writev_all;
 pub(crate) use writev_all::writev_at_all;

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -1,64 +1,69 @@
+use io_uring::cqueue::Entry;
+
 use crate::buf::BoundedBufMut;
 use crate::io::SharedFd;
-use crate::BufResult;
+use crate::{BufResult, OneshotOutputTransform, UnsubmittedOneshot};
 
-use crate::runtime::driver::op::{Completable, CqeResult, Op};
-use crate::runtime::CONTEXT;
 use std::io;
+use std::marker::PhantomData;
 
-pub(crate) struct Read<T> {
+/// An unsubmitted read operation.
+pub type UnsubmittedRead<T> = UnsubmittedOneshot<ReadData<T>, ReadTransform<T>>;
+
+#[allow(missing_docs)]
+pub struct ReadData<T> {
     /// Holds a strong ref to the FD, preventing the file from being closed
     /// while the operation is in-flight.
-    #[allow(dead_code)]
-    fd: SharedFd,
+    _fd: SharedFd,
 
-    /// Reference to the in-flight buffer.
-    pub(crate) buf: T,
+    buf: T,
 }
 
-impl<T: BoundedBufMut> Op<Read<T>> {
-    pub(crate) fn read_at(fd: &SharedFd, buf: T, offset: u64) -> io::Result<Op<Read<T>>> {
-        use io_uring::{opcode, types};
-
-        CONTEXT.with(|x| {
-            x.handle().expect("Not in a runtime context").submit_op(
-                Read {
-                    fd: fd.clone(),
-                    buf,
-                },
-                |read| {
-                    // Get raw buffer info
-                    let ptr = read.buf.stable_mut_ptr();
-                    let len = read.buf.bytes_total();
-                    opcode::Read::new(types::Fd(fd.raw_fd()), ptr, len as _)
-                        .offset(offset as _)
-                        .build()
-                },
-            )
-        })
-    }
+#[allow(missing_docs)]
+pub struct ReadTransform<T> {
+    _phantom: PhantomData<T>,
 }
 
-impl<T> Completable for Read<T>
+impl<T> OneshotOutputTransform for ReadTransform<T>
 where
     T: BoundedBufMut,
 {
     type Output = BufResult<usize, T>;
+    type StoredData = ReadData<T>;
 
-    fn complete(self, cqe: CqeResult) -> Self::Output {
-        // Convert the operation result to `usize`
-        let res = cqe.result.map(|v| v as usize);
-        // Recover the buffer
-        let mut buf = self.buf;
-
-        // If the operation was successful, advance the initialized cursor.
-        if let Ok(n) = res {
+    fn transform_oneshot_output(self, mut data: Self::StoredData, cqe: Entry) -> Self::Output {
+        let n = cqe.result();
+        let res = if n >= 0 {
             // Safety: the kernel wrote `n` bytes to the buffer.
-            unsafe {
-                buf.set_init(n);
-            }
-        }
+            unsafe { data.buf.set_init(n as usize) };
+            Ok(n as usize)
+        } else {
+            Err(io::Error::from_raw_os_error(-n))
+        };
 
-        (res, buf)
+        (res, data.buf)
+    }
+}
+
+impl<T: BoundedBufMut> UnsubmittedRead<T> {
+    pub(crate) fn read_at(fd: &SharedFd, mut buf: T, offset: u64) -> Self {
+        use io_uring::{opcode, types};
+
+        // Get raw buffer info
+        let ptr = buf.stable_mut_ptr();
+        let len = buf.bytes_total();
+
+        Self::new(
+            ReadData {
+                _fd: fd.clone(),
+                buf,
+            },
+            ReadTransform {
+                _phantom: PhantomData,
+            },
+            opcode::Read::new(types::Fd(fd.raw_fd()), ptr, len as _)
+                .offset(offset as _)
+                .build(),
+        )
     }
 }

--- a/src/io/readv.rs
+++ b/src/io/readv.rs
@@ -1,13 +1,17 @@
 use crate::buf::BoundedBufMut;
-use crate::BufResult;
+use crate::{BufResult, OneshotOutputTransform, UnsubmittedOneshot};
 
 use crate::io::SharedFd;
-use crate::runtime::driver::op::{Completable, CqeResult, Op};
-use crate::runtime::CONTEXT;
+use io_uring::cqueue::Entry;
 use libc::iovec;
 use std::io;
+use std::marker::PhantomData;
 
-pub(crate) struct Readv<T> {
+/// An unsubmitted readv operation.
+pub type UnsubmittedReadv<T> = UnsubmittedOneshot<ReadvData<T>, ReadvTransform<T>>;
+
+#[allow(missing_docs)]
+pub struct ReadvData<T> {
     /// Holds a strong ref to the FD, preventing the file from being closed
     /// while the operation is in-flight.
     #[allow(dead_code)]
@@ -15,64 +19,31 @@ pub(crate) struct Readv<T> {
 
     /// Reference to the in-flight buffer.
     pub(crate) bufs: Vec<T>,
+
     /// Parameter for `io_uring::op::readv`, referring `bufs`.
+    #[allow(dead_code)]
     iovs: Vec<iovec>,
 }
 
-impl<T: BoundedBufMut> Op<Readv<T>> {
-    pub(crate) fn readv_at(
-        fd: &SharedFd,
-        mut bufs: Vec<T>,
-        offset: u64,
-    ) -> io::Result<Op<Readv<T>>> {
-        use io_uring::{opcode, types};
-
-        // Build `iovec` objects referring the provided `bufs` for `io_uring::opcode::Readv`.
-        let iovs: Vec<iovec> = bufs
-            .iter_mut()
-            .map(|b| iovec {
-                // Safety guaranteed by `BoundedBufMut`.
-                iov_base: unsafe { b.stable_mut_ptr().add(b.bytes_init()) as *mut libc::c_void },
-                iov_len: b.bytes_total() - b.bytes_init(),
-            })
-            .collect();
-
-        CONTEXT.with(|x| {
-            x.handle().expect("Not in a runtime context").submit_op(
-                Readv {
-                    fd: fd.clone(),
-                    bufs,
-                    iovs,
-                },
-                |read| {
-                    opcode::Readv::new(
-                        types::Fd(fd.raw_fd()),
-                        read.iovs.as_ptr(),
-                        read.iovs.len() as u32,
-                    )
-                    .offset(offset as _)
-                    .build()
-                },
-            )
-        })
-    }
+#[allow(missing_docs)]
+pub struct ReadvTransform<T> {
+    _phantom: PhantomData<T>,
 }
 
-impl<T> Completable for Readv<T>
+impl<T> OneshotOutputTransform for ReadvTransform<T>
 where
     T: BoundedBufMut,
 {
     type Output = BufResult<usize, Vec<T>>;
+    type StoredData = ReadvData<T>;
 
-    fn complete(self, cqe: CqeResult) -> Self::Output {
-        // Convert the operation result to `usize`
-        let res = cqe.result.map(|v| v as usize);
+    fn transform_oneshot_output(self, data: Self::StoredData, cqe: Entry) -> Self::Output {
         // Recover the buffer
-        let mut bufs = self.bufs;
+        let mut bufs = data.bufs;
 
-        // If the operation was successful, advance the initialized cursor.
-        if let Ok(n) = res {
-            let mut count = n;
+        let res = if cqe.result() >= 0 {
+            // If the operation was successful, advance the initialized cursor.
+            let mut count = cqe.result() as usize;
             for b in bufs.iter_mut() {
                 let sz = std::cmp::min(count, b.bytes_total() - b.bytes_init());
                 let pos = b.bytes_init() + sz;
@@ -85,8 +56,44 @@ where
                 }
             }
             assert_eq!(count, 0);
-        }
+            Ok(cqe.result() as usize)
+        } else {
+            Err(io::Error::from_raw_os_error(-cqe.result()))
+        };
 
         (res, bufs)
+    }
+}
+
+impl<T: BoundedBufMut> UnsubmittedReadv<T> {
+    pub(crate) fn readv_at(fd: &SharedFd, mut bufs: Vec<T>, offset: u64) -> Self {
+        use io_uring::{opcode, types};
+
+        let iovs: Vec<iovec> = bufs
+            .iter_mut()
+            .map(|b| iovec {
+                // Safety guaranteed by `BoundedBufMut`.
+                iov_base: unsafe { b.stable_mut_ptr().add(b.bytes_init()) as *mut libc::c_void },
+                iov_len: b.bytes_total() - b.bytes_init(),
+            })
+            .collect();
+
+        // Get raw buffer info
+        let ptr = iovs.as_ptr();
+        let len = iovs.len();
+
+        Self::new(
+            ReadvData {
+                fd: fd.clone(),
+                bufs,
+                iovs,
+            },
+            ReadvTransform {
+                _phantom: PhantomData,
+            },
+            opcode::Readv::new(types::Fd(fd.raw_fd()), ptr, len as _)
+                .offset(offset as _)
+                .build(),
+        )
     }
 }

--- a/src/io/socket.rs
+++ b/src/io/socket.rs
@@ -169,8 +169,7 @@ impl Socket {
     }
 
     pub(crate) async fn read<T: BoundedBufMut>(&self, buf: T) -> crate::BufResult<usize, T> {
-        let op = Op::read_at(&self.fd, buf, 0).unwrap();
-        op.await
+        UnsubmittedOneshot::read_at(&self.fd, buf, 0).submit().await
     }
 
     pub(crate) async fn read_fixed<T>(&self, buf: T) -> crate::BufResult<usize, T>

--- a/src/io/socket.rs
+++ b/src/io/socket.rs
@@ -129,9 +129,10 @@ impl Socket {
         (Ok(()), buf.into_inner())
     }
 
-    pub async fn writev<T: BoundedBuf>(&self, buf: Vec<T>) -> crate::BufResult<usize, Vec<T>> {
-        let op = Op::writev_at(&self.fd, buf, 0).unwrap();
-        op.await
+    pub async fn writev<T: BoundedBuf>(&self, bufs: Vec<T>) -> crate::BufResult<usize, Vec<T>> {
+        UnsubmittedOneshot::writev_at(&self.fd, bufs, 0)
+            .submit()
+            .await
     }
 
     pub(crate) async fn send_to<T: BoundedBuf>(

--- a/src/io/socket.rs
+++ b/src/io/socket.rs
@@ -1,5 +1,5 @@
 use crate::io::write::UnsubmittedWrite;
-use crate::runtime::driver::op::Op;
+use crate::runtime::driver::op::{Op, Submit};
 use crate::{
     buf::fixed::FixedBuf,
     buf::{BoundedBuf, BoundedBufMut, IoBuf, Slice},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,9 @@ pub mod fs;
 pub mod net;
 
 pub use io::read::*;
+pub use io::readv::*;
 pub use io::write::*;
+pub use io::writev::*;
 pub use runtime::driver::op::{
     InFlightOneshot, Link, LinkedInFlightOneshot, OneshotOutputTransform, Submit,
     UnsubmittedOneshot,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!         // Read some data, the buffer is passed by ownership and
 //!         // submitted to the kernel. When the operation completes,
 //!         // we get the buffer back.
-//!         let (res, buf) = file.read_at(buf, 0).await;
+//!         let (res, buf) = file.read_at(buf, 0).submit().await;
 //!         let n = res?;
 //!
 //!         // Display the contents
@@ -78,6 +78,7 @@ pub mod buf;
 pub mod fs;
 pub mod net;
 
+pub use io::read::*;
 pub use io::write::*;
 pub use runtime::driver::op::{InFlightOneshot, OneshotOutputTransform, UnsubmittedOneshot};
 pub use runtime::spawn;
@@ -115,7 +116,7 @@ use std::future::Future;
 ///         // Read some data, the buffer is passed by ownership and
 ///         // submitted to the kernel. When the operation completes,
 ///         // we get the buffer back.
-///         let (res, buf) = file.read_at(buf, 0).await;
+///         let (res, buf) = file.read_at(buf, 0).submit().await;
 ///         let n = res?;
 ///
 ///         // Display the contents
@@ -254,7 +255,7 @@ impl Builder {
 ///         // Read some data, the buffer is passed by ownership and
 ///         // submitted to the kernel. When the operation completes,
 ///         // we get the buffer back.
-///         let (res, buf) = file.read_at(buf, 0).await;
+///         let (res, buf) = file.read_at(buf, 0).submit().await;
 ///         let n = res?;
 ///
 ///         // Display the contents

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ macro_rules! syscall {
 #[macro_use]
 mod future;
 mod io;
-mod runtime;
+pub mod runtime;
 
 pub mod buf;
 pub mod fs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //!
 //! ```no_run
 //! use tokio_uring::fs::File;
+//! use tokio_uring::Submit;
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     tokio_uring::start(async {
@@ -80,7 +81,10 @@ pub mod net;
 
 pub use io::read::*;
 pub use io::write::*;
-pub use runtime::driver::op::{InFlightOneshot, OneshotOutputTransform, UnsubmittedOneshot};
+pub use runtime::driver::op::{
+    InFlightOneshot, Link, LinkedInFlightOneshot, OneshotOutputTransform, Submit,
+    UnsubmittedOneshot,
+};
 pub use runtime::spawn;
 pub use runtime::Runtime;
 
@@ -106,6 +110,7 @@ use std::future::Future;
 ///
 /// ```no_run
 /// use tokio_uring::fs::File;
+/// use tokio_uring::Submit;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     tokio_uring::start(async {
@@ -245,6 +250,7 @@ impl Builder {
 ///
 /// ```no_run
 /// use tokio_uring::fs::File;
+/// use tokio_uring::Submit;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     tokio_uring::start(async {

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -16,6 +16,7 @@ use std::{
 /// ```
 /// use tokio_uring::net::TcpListener;
 /// use tokio_uring::net::TcpStream;
+/// use tokio_uring::Submit;
 ///
 /// let listener = TcpListener::bind("127.0.0.1:2345".parse().unwrap()).unwrap();
 ///

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -20,6 +20,7 @@ use crate::{
 ///
 /// ```no_run
 /// use tokio_uring::net::TcpStream;
+/// use tokio_uring::Submit;
 /// use std::net::ToSocketAddrs;
 ///
 /// fn main() -> std::io::Result<()> {

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -26,6 +26,7 @@ use std::{
 ///
 /// ```
 /// use tokio_uring::net::UdpSocket;
+/// use tokio_uring::Submit;
 /// use std::net::SocketAddr;
 /// fn main() -> std::io::Result<()> {
 ///     tokio_uring::start(async {

--- a/src/net/unix/listener.rs
+++ b/src/net/unix/listener.rs
@@ -12,6 +12,7 @@ use std::{io, path::Path};
 /// ```
 /// use tokio_uring::net::UnixListener;
 /// use tokio_uring::net::UnixStream;
+/// use tokio_uring::Submit;
 ///
 /// let sock_file = "/tmp/tokio-uring-unix-test.sock";
 /// let listener = UnixListener::bind(&sock_file).unwrap();

--- a/src/net/unix/stream.rs
+++ b/src/net/unix/stream.rs
@@ -20,6 +20,7 @@ use std::{
 ///
 /// ```no_run
 /// use tokio_uring::net::UnixStream;
+/// use tokio_uring::Submit;
 /// use std::net::ToSocketAddrs;
 ///
 /// fn main() -> std::io::Result<()> {

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -3,7 +3,7 @@ use crate::runtime::driver::{Handle, WeakHandle};
 use std::cell::RefCell;
 
 /// Owns the driver and resides in thread-local storage.
-pub(crate) struct RuntimeContext {
+pub struct RuntimeContext {
     driver: RefCell<Option<driver::Handle>>,
 }
 
@@ -41,7 +41,7 @@ impl RuntimeContext {
             .unwrap_or(false)
     }
 
-    pub(crate) fn handle(&self) -> Option<Handle> {
+    pub fn handle(&self) -> Option<Handle> {
         self.driver.borrow().clone()
     }
 

--- a/src/runtime/driver/handle.rs
+++ b/src/runtime/driver/handle.rs
@@ -25,7 +25,7 @@ use crate::runtime::driver::op::{Completable, MultiCQEFuture, Op, Updateable};
 use crate::runtime::driver::Driver;
 
 #[derive(Clone)]
-pub(crate) struct Handle {
+pub struct Handle {
     pub(super) inner: Rc<RefCell<Driver>>,
 }
 
@@ -63,8 +63,20 @@ impl Handle {
         self.inner.borrow_mut().unregister_buffers(buffers)
     }
 
+    pub fn register_files(&self, fds: &[RawFd]) -> io::Result<()> {
+        self.inner.borrow_mut().register_files(fds)
+    }
+
+    pub fn unregister_files(&self) -> io::Result<()> {
+        self.inner.borrow_mut().unregister_files()
+    }
+
     pub(crate) fn submit_op_2(&self, sqe: squeue::Entry) -> usize {
         self.inner.borrow_mut().submit_op_2(sqe)
+    }
+
+    pub fn submit_ops(&self, sqes: impl Iterator<Item = squeue::Entry>) -> Vec<usize> {
+        self.inner.borrow_mut().submit_ops(sqes)
     }
 
     pub(crate) fn submit_op<T, S, F>(&self, data: T, f: F) -> io::Result<Op<T, S>>

--- a/src/runtime/driver/op/link.rs
+++ b/src/runtime/driver/op/link.rs
@@ -1,0 +1,92 @@
+use io_uring::squeue::Flags;
+use pin_project_lite::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use crate::{OneshotOutputTransform, Submit, UnsubmittedOneshot};
+
+/// A Link struct to represent linked operations.
+pub struct Link<D, N> {
+    data: D,
+    next: N,
+}
+
+impl<D, N> Link<D, N> {
+    /// Construct a new Link with actual data and next node (Link or UnsubmittedOneshot).
+    pub fn new(data: D, next: N) -> Self {
+        Self { data, next }
+    }
+}
+
+impl<D, N> Submit for Link<D, N>
+where
+    D: Submit,
+    N: Submit,
+{
+    type Output = LinkedInFlightOneshot<D::Output, N::Output>;
+
+    fn submit(self) -> Self::Output {
+        LinkedInFlightOneshot {
+            data: self.data.submit(),
+            next: Some(self.next.submit()),
+        }
+    }
+}
+
+impl<D1, T1: OneshotOutputTransform<StoredData = D1>, N> Link<UnsubmittedOneshot<D1, T1>, N> {
+    /// Construct a new soft Link with current Link and other UnsubmittedOneshot.
+    pub fn link<D2, T2: OneshotOutputTransform<StoredData = D2>>(
+        self,
+        other: UnsubmittedOneshot<D2, T2>,
+    ) -> Link<UnsubmittedOneshot<D1, T1>, Link<N, UnsubmittedOneshot<D2, T2>>> {
+        Link {
+            data: self.data.set_flags(Flags::IO_LINK),
+            next: Link {
+                data: self.next,
+                next: other,
+            },
+        }
+    }
+
+    /// Construct a new hard Link with current Link and other UnsubmittedOneshot.
+    pub fn hard_link<D2, T2: OneshotOutputTransform<StoredData = D2>>(
+        self,
+        other: UnsubmittedOneshot<D2, T2>,
+    ) -> Link<UnsubmittedOneshot<D1, T1>, Link<N, UnsubmittedOneshot<D2, T2>>> {
+        Link {
+            data: self.data.set_flags(Flags::IO_HARDLINK),
+            next: Link {
+                data: self.next,
+                next: other,
+            },
+        }
+    }
+}
+
+pin_project! {
+    /// An in-progress linked oneshot operations which can be polled for completion.
+    pub struct LinkedInFlightOneshot<D, N> {
+        #[pin]
+        data: D,
+        next: Option<N>,
+    }
+}
+
+impl<D, N> Future for LinkedInFlightOneshot<D, N>
+where
+    D: Future,
+{
+    type Output = (D::Output, N); // Will return actual output and next linked future.
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        let output = ready!(this.data.poll(cx));
+        let next = this.next.take().unwrap();
+
+        Poll::Ready((output, next))
+    }
+}

--- a/src/runtime/driver/op/mod.rs
+++ b/src/runtime/driver/op/mod.rs
@@ -7,8 +7,10 @@ use std::task::{Context, Poll, Waker};
 use io_uring::squeue::Flags;
 use io_uring::{cqueue, squeue};
 
+mod link;
 mod slab_list;
 
+pub use link::{Link, LinkedInFlightOneshot};
 use slab::Slab;
 use slab_list::{SlabListEntry, SlabListIndices};
 
@@ -38,29 +40,43 @@ impl<D, T: OneshotOutputTransform<StoredData = D>> UnsubmittedOneshot<D, T> {
         }
     }
 
+    /// Link two UnsubmittedOneshots.
+    pub fn link<D2, T2: OneshotOutputTransform<StoredData = D2>>(
+        self,
+        other: UnsubmittedOneshot<D2, T2>,
+    ) -> Link<UnsubmittedOneshot<D, T>, UnsubmittedOneshot<D2, T2>> {
+        Link::new(self.set_flags(Flags::IO_LINK), other)
+    }
+
+    /// Hard-link two UnsubmittedOneshots.
+    pub fn hard_link<D2, T2: OneshotOutputTransform<StoredData = D2>>(
+        self,
+        other: UnsubmittedOneshot<D2, T2>,
+    ) -> Link<UnsubmittedOneshot<D, T>, UnsubmittedOneshot<D2, T2>> {
+        Link::new(self.set_flags(Flags::IO_HARDLINK), other)
+    }
+
     /// Set the SQE's flags.
-    pub fn set_flags(mut self, flags: Flags) -> Self {
+    pub(crate) fn set_flags(mut self, flags: Flags) -> Self {
         self.sqe = self.sqe.flags(flags);
         self
     }
+}
+
+impl<D, T: OneshotOutputTransform<StoredData = D>> Submit for UnsubmittedOneshot<D, T> {
+    type Output = InFlightOneshot<D, T>;
 
     /// Submit an operation to the driver for batched entry to the kernel.
-    pub fn submit(self) -> InFlightOneshot<D, T> {
+    fn submit(self) -> Self::Output {
         let handle = CONTEXT
             .with(|x| x.handle())
             .expect("Could not submit op; not in runtime context");
 
-        self.submit_with_driver(&handle)
-    }
-
-    fn submit_with_driver(self, driver: &driver::Handle) -> InFlightOneshot<D, T> {
-        let index = driver.submit_op_2(self.sqe);
-
-        let driver = driver.into();
+        let index = handle.submit_op_2(self.sqe);
 
         let inner = InFlightOneshotInner {
             index,
-            driver,
+            driver: (&handle).into(),
             stable_data: self.stable_data,
             post_op: self.post_op,
         };
@@ -119,6 +135,15 @@ impl<D: 'static, T: OneshotOutputTransform<StoredData = D>> Drop for InFlightOne
             }
         }
     }
+}
+
+/// Submit an operation or operations to the driver.
+pub trait Submit {
+    /// The output of the submission with an in-flight operation or linked in-flight operations.
+    type Output;
+
+    /// Submit an operation or linked operations.
+    fn submit(self) -> Self::Output;
 }
 
 /// Transforms the output of a oneshot operation into a more user-friendly format.

--- a/src/runtime/driver/op/mod.rs
+++ b/src/runtime/driver/op/mod.rs
@@ -57,7 +57,7 @@ impl<D, T: OneshotOutputTransform<StoredData = D>> UnsubmittedOneshot<D, T> {
     }
 
     /// Set the SQE's flags.
-    pub(crate) fn set_flags(mut self, flags: Flags) -> Self {
+    pub fn set_flags(mut self, flags: Flags) -> Self {
         self.sqe = self.sqe.flags(flags);
         self
     }

--- a/src/runtime/driver/op/mod.rs
+++ b/src/runtime/driver/op/mod.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll, Waker};
 
+use io_uring::squeue::Flags;
 use io_uring::{cqueue, squeue};
 
 mod slab_list;
@@ -35,6 +36,12 @@ impl<D, T: OneshotOutputTransform<StoredData = D>> UnsubmittedOneshot<D, T> {
             post_op,
             sqe,
         }
+    }
+
+    /// Set the SQE's flags.
+    pub fn set_flags(mut self, flags: Flags) -> Self {
+        self.sqe = self.sqe.flags(flags);
+        self
     }
 
     /// Submit an operation to the driver for batched entry to the kernel.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod driver;
 pub(crate) use context::RuntimeContext;
 
 thread_local! {
-    pub(crate) static CONTEXT: RuntimeContext = RuntimeContext::new();
+    pub static CONTEXT: RuntimeContext = RuntimeContext::new();
 }
 
 /// The Runtime Executor
@@ -29,7 +29,7 @@ pub struct Runtime {
     local: ManuallyDrop<LocalSet>,
 
     /// Strong reference to the driver.
-    driver: driver::Handle,
+    pub driver: driver::Handle,
 }
 
 /// Spawns a new asynchronous task, returning a [`JoinHandle`] for it.

--- a/tests/driver.rs
+++ b/tests/driver.rs
@@ -1,6 +1,6 @@
 use tempfile::NamedTempFile;
 
-use tokio_uring::{buf::IoBuf, fs::File};
+use tokio_uring::{buf::IoBuf, fs::File, Submit};
 
 #[path = "../src/future.rs"]
 #[allow(warnings)]

--- a/tests/driver.rs
+++ b/tests/driver.rs
@@ -58,6 +58,7 @@ fn complete_ops_on_drop() {
                 },
                 25 * 1024 * 1024,
             )
+            .submit()
             .await
             .0
             .unwrap();

--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -75,7 +75,7 @@ fn vectored_read() {
 
         let file = File::open(tempfile.path()).await.unwrap();
         let bufs = vec![Vec::<u8>::with_capacity(5), Vec::<u8>::with_capacity(9)];
-        let (res, bufs) = file.readv_at(bufs, 0).await;
+        let (res, bufs) = file.readv_at(bufs, 0).submit().await;
         let n = res.unwrap();
 
         assert_eq!(n, HELLO.len());
@@ -93,7 +93,7 @@ fn vectored_write() {
         let buf2 = " world...".to_owned().into_bytes();
         let bufs = vec![buf1, buf2];
 
-        file.writev_at(bufs, 0).await.0.unwrap();
+        file.writev_at(bufs, 0).submit().await.0.unwrap();
 
         let file = std::fs::read(tempfile.path()).unwrap();
         assert_eq!(file, HELLO);


### PR DESCRIPTION
This PR introduces two API changes: 

1. Add `UnsubmittedRead` in read part,
2. Introduce `Submit` and `Link` struct.

(1) is basically following suggested API change in: https://github.com/tokio-rs/tokio-uring/pull/244 and (2) is for linked operations.

User now can link their operations like below

```rust
let read1 = file
    .read_at(buf1, 0);
let read2 = file.read_at(buf2, HELLO.len() as u64).;
let write = file.write(HELLO);

let (res1, read2_future) = read1.link(read2).link(write).submit().await;
let (res2, write_future) = read2_future.await;
let res3 = write_future.await;
```

Closes: https://github.com/tokio-rs/tokio-uring/issues/289
