### PR TITLE
Refresh: Update `Result<T, B>` to be `Result<(T,B), Error<B>`

### DIFF
--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -29,9 +29,7 @@ fn main() {
 
         loop {
             // Read a chunk
-            let (res, b) = file.read_at(buf, pos).await;
-            let n = res.unwrap();
-
+            let (n, b) = file.read_at(buf, pos).await.unwrap();
             if n == 0 {
                 break;
             }

--- a/examples/mix.rs
+++ b/examples/mix.rs
@@ -34,15 +34,14 @@ fn main() {
 
                 loop {
                     // Read a chunk
-                    let (res, b) = file.read_at(buf, pos).await;
-                    let n = res.unwrap();
+                    let (n, b) = file.read_at(buf, pos).await.unwrap();
 
                     if n == 0 {
                         break;
                     }
 
-                    let (res, b) = socket.write(b).submit().await;
-                    pos += res.unwrap() as u64;
+                    let (n, b) = socket.write(b).submit().await.unwrap();
+                    pos += n as u64;
 
                     buf = b;
                 }

--- a/examples/tcp_listener.rs
+++ b/examples/tcp_listener.rs
@@ -29,16 +29,14 @@ fn main() {
 
                 let mut buf = vec![0u8; 4096];
                 loop {
-                    let (result, nbuf) = stream.read(buf).await;
+                    let (read, nbuf) = stream.read(buf).await.unwrap();
                     buf = nbuf;
-                    let read = result.unwrap();
                     if read == 0 {
                         println!("{} closed, {} total ping-ponged", socket_addr, n);
                         break;
                     }
 
-                    let (res, slice) = stream.write_all(buf.slice(..read)).await;
-                    let _ = res.unwrap();
+                    let (_, slice) = stream.write_all(buf.slice(..read)).await.unwrap();
                     buf = slice.into_inner();
                     println!("{} all {} bytes ping-ponged", socket_addr, read);
                     n += read;

--- a/examples/tcp_listener_fixed_buffers.rs
+++ b/examples/tcp_listener_fixed_buffers.rs
@@ -79,17 +79,14 @@ async fn echo_handler<T: IoBufMut>(
         // Each time through the loop, use fbuf and then get it back for the next
         // iteration.
 
-        let (result, fbuf1) = stream.read_fixed(fbuf).await;
+        let (read, fbuf1) = stream.read_fixed(fbuf).await.unwrap();
         fbuf = {
-            let read = result.unwrap();
             if read == 0 {
                 break;
             }
             assert_eq!(4096, fbuf1.len()); // To prove a point.
 
-            let (res, nslice) = stream.write_fixed_all(fbuf1.slice(..read)).await;
-
-            let _ = res.unwrap();
+            let (_, nslice) = stream.write_fixed_all(fbuf1.slice(..read)).await.unwrap();
             println!("peer {} all {} bytes ping-ponged", peer, read);
             n += read;
 

--- a/examples/tcp_stream.rs
+++ b/examples/tcp_stream.rs
@@ -15,11 +15,10 @@ fn main() {
         let stream = TcpStream::connect(socket_addr).await.unwrap();
         let buf = vec![1u8; 128];
 
-        let (result, buf) = stream.write(buf).submit().await;
-        println!("written: {}", result.unwrap());
+        let (n, buf) = stream.write(buf).submit().await.unwrap();
+        println!("written: {}", n);
 
-        let (result, buf) = stream.read(buf).await;
-        let read = result.unwrap();
+        let (read, buf) = stream.read(buf).await.unwrap();
         println!("read: {:?}", &buf[..read]);
     });
 }

--- a/examples/udp_socket.rs
+++ b/examples/udp_socket.rs
@@ -15,12 +15,11 @@ fn main() {
 
         let buf = vec![0u8; 128];
 
-        let (result, mut buf) = socket.recv_from(buf).await;
-        let (read, socket_addr) = result.unwrap();
+        let ((read, socket_addr), mut buf) = socket.recv_from(buf).await.unwrap();
         buf.resize(read, 0);
         println!("received from {}: {:?}", socket_addr, &buf[..]);
 
-        let (result, _buf) = socket.send_to(buf, socket_addr).await;
-        println!("sent to {}: {}", socket_addr, result.unwrap());
+        let (n, _buf) = socket.send_to(buf, socket_addr).await.unwrap();
+        println!("sent to {}: {}", socket_addr, n);
     });
 }

--- a/examples/unix_listener.rs
+++ b/examples/unix_listener.rs
@@ -20,11 +20,10 @@ fn main() {
             tokio_uring::spawn(async move {
                 let buf = vec![1u8; 128];
 
-                let (result, buf) = stream.write(buf).submit().await;
-                println!("written to {}: {}", &socket_addr, result.unwrap());
+                let (n, buf) = stream.write(buf).submit().await.unwrap();
+                println!("written to {}: {}", &socket_addr, n);
 
-                let (result, buf) = stream.read(buf).await;
-                let read = result.unwrap();
+                let (read, buf) = stream.read(buf).await.unwrap();
                 println!("read from {}: {:?}", &socket_addr, &buf[..read]);
             });
         }

--- a/examples/unix_stream.rs
+++ b/examples/unix_stream.rs
@@ -15,11 +15,10 @@ fn main() {
         let stream = UnixStream::connect(socket_addr).await.unwrap();
         let buf = vec![1u8; 128];
 
-        let (result, buf) = stream.write(buf).submit().await;
-        println!("written: {}", result.unwrap());
+        let (n, buf) = stream.write(buf).submit().await.unwrap();
+        println!("written: {}", n);
 
-        let (result, buf) = stream.read(buf).await;
-        let read = result.unwrap();
+        let (read, buf) = stream.read(buf).await.unwrap();
         println!("read: {:?}", &buf[..read]);
     });
 }

--- a/examples/wrk-bench.rs
+++ b/examples/wrk-bench.rs
@@ -21,8 +21,7 @@ fn main() -> io::Result<()> {
                     let (stream, _) = listener.accept().await?;
 
                     tokio_uring::spawn(async move {
-                        let (result, _) = stream.write(RESPONSE).submit().await;
-
+                        let result = stream.write(RESPONSE).submit().await;
                         if let Err(err) = result {
                             eprintln!("Client connection failed: {}", err);
                         }

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -1,6 +1,6 @@
 use crate::buf::BoundedBufMut;
 use crate::io::SharedFd;
-use crate::BufResult;
+use crate::Result;
 
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
@@ -43,7 +43,7 @@ impl<T> Completable for Read<T>
 where
     T: BoundedBufMut,
 {
-    type Output = BufResult<usize, T>;
+    type Output = Result<usize, T>;
 
     fn complete(self, cqe: CqeResult) -> Self::Output {
         // Convert the operation result to `usize`
@@ -59,6 +59,9 @@ where
             }
         }
 
-        (res, buf)
+        match res {
+            Ok(n) => Ok((n, buf)),
+            Err(e) => Err(crate::Error(e, buf)),
+        }
     }
 }

--- a/src/io/readv.rs
+++ b/src/io/readv.rs
@@ -1,5 +1,5 @@
 use crate::buf::BoundedBufMut;
-use crate::BufResult;
+use crate::Result;
 
 use crate::io::SharedFd;
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
@@ -62,7 +62,7 @@ impl<T> Completable for Readv<T>
 where
     T: BoundedBufMut,
 {
-    type Output = BufResult<usize, Vec<T>>;
+    type Output = Result<usize, Vec<T>>;
 
     fn complete(self, cqe: CqeResult) -> Self::Output {
         // Convert the operation result to `usize`
@@ -87,6 +87,9 @@ where
             assert_eq!(count, 0);
         }
 
-        (res, bufs)
+        match res {
+            Ok(n) => Ok((n, bufs)),
+            Err(e) => Err(crate::Error(e, bufs)),
+        }
     }
 }

--- a/src/io/recv_from.rs
+++ b/src/io/recv_from.rs
@@ -1,6 +1,6 @@
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
-use crate::{buf::BoundedBufMut, io::SharedFd, BufResult};
+use crate::{buf::BoundedBufMut, io::SharedFd, Result};
 use socket2::SockAddr;
 use std::{
     io::IoSliceMut,
@@ -57,7 +57,7 @@ impl<T> Completable for RecvFrom<T>
 where
     T: BoundedBufMut,
 {
-    type Output = BufResult<(usize, SocketAddr), T>;
+    type Output = Result<(usize, SocketAddr), T>;
 
     fn complete(self, cqe: CqeResult) -> Self::Output {
         // Convert the operation result to `usize`
@@ -78,6 +78,9 @@ where
             (n, socket_addr)
         });
 
-        (res, buf)
+        match res {
+            Ok(n) => Ok((n, buf)),
+            Err(e) => Err(crate::Error(e, buf)),
+        }
     }
 }

--- a/src/io/recvmsg.rs
+++ b/src/io/recvmsg.rs
@@ -1,6 +1,6 @@
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
-use crate::{buf::BoundedBufMut, io::SharedFd, BufResult};
+use crate::{buf::BoundedBufMut, io::SharedFd, Result};
 use socket2::SockAddr;
 use std::{
     io::IoSliceMut,
@@ -61,7 +61,7 @@ impl<T> Completable for RecvMsg<T>
 where
     T: BoundedBufMut,
 {
-    type Output = BufResult<(usize, SocketAddr), Vec<T>>;
+    type Output = Result<(usize, SocketAddr), Vec<T>>;
 
     fn complete(self, cqe: CqeResult) -> Self::Output {
         // Convert the operation result to `usize`
@@ -92,6 +92,9 @@ where
             (n, socket_addr)
         });
 
-        (res, bufs)
+        match res {
+            Ok(n) => Ok((n, bufs)),
+            Err(e) => Err(crate::Error(e, bufs)),
+        }
     }
 }

--- a/src/io/write_fixed.rs
+++ b/src/io/write_fixed.rs
@@ -2,7 +2,7 @@ use crate::buf::fixed::FixedBuf;
 use crate::buf::BoundedBuf;
 use crate::io::SharedFd;
 use crate::runtime::driver::op::{self, Completable, Op};
-use crate::BufResult;
+use crate::Result;
 
 use crate::runtime::CONTEXT;
 use std::io;
@@ -48,7 +48,7 @@ where
 }
 
 impl<T> Completable for WriteFixed<T> {
-    type Output = BufResult<usize, T>;
+    type Output = Result<usize, T>;
 
     fn complete(self, cqe: op::CqeResult) -> Self::Output {
         // Convert the operation result to `usize`
@@ -56,6 +56,9 @@ impl<T> Completable for WriteFixed<T> {
         // Recover the buffer
         let buf = self.buf;
 
-        (res, buf)
+        match res {
+            Ok(n) => Ok((n, buf)),
+            Err(e) => Err(crate::Error(e, buf)),
+        }
     }
 }

--- a/src/io/writev_all.rs
+++ b/src/io/writev_all.rs
@@ -17,7 +17,7 @@ pub(crate) async fn writev_at_all<T: BoundedBuf>(
     fd: &SharedFd,
     mut bufs: Vec<T>,
     offset: Option<u64>,
-) -> crate::BufResult<usize, Vec<T>> {
+) -> crate::Result<usize, Vec<T>> {
     // TODO decide if the function should return immediately if all the buffer lengths
     // were to sum to zero. That would save an allocation and one call into writev.
 
@@ -59,7 +59,7 @@ pub(crate) async fn writev_at_all<T: BoundedBuf>(
 
             // On error, there is no indication how many bytes were written. This is standard.
             // The device doesn't tell us that either.
-            Err(e) => return (Err(e), bufs),
+            Err(e) => return Err(crate::Error(e, bufs)),
         };
 
         // TODO if n is zero, while there was more data to be written, should this be interpreted
@@ -101,7 +101,7 @@ pub(crate) async fn writev_at_all<T: BoundedBuf>(
             break;
         }
     }
-    (Ok(total), bufs)
+    Ok((total, bufs))
 }
 
 struct WritevAll<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,8 @@ pub use runtime::spawn;
 pub use runtime::Runtime;
 
 use crate::runtime::driver::op::Op;
+use std::error::Error;
+use std::fmt::{Debug, Display};
 use std::future::Future;
 
 /// Starts an `io_uring` enabled Tokio runtime.
@@ -237,8 +239,7 @@ impl Builder {
 ///
 /// This type is used as a return value for asynchronous `io-uring` methods that
 /// require passing ownership of a buffer to the runtime. When the operation
-/// completes, the buffer is returned whether or not the operation completed
-/// successfully.
+/// completes, the buffer is returned both in the success tuple and as part of the error.
 ///
 /// # Examples
 ///
@@ -254,8 +255,7 @@ impl Builder {
 ///         // Read some data, the buffer is passed by ownership and
 ///         // submitted to the kernel. When the operation completes,
 ///         // we get the buffer back.
-///         let (res, buf) = file.read_at(buf, 0).await;
-///         let n = res?;
+///         let (n, buf) = file.read_at(buf, 0).await?;
 ///
 ///         // Display the contents
 ///         println!("{:?}", &buf[..n]);
@@ -264,7 +264,32 @@ impl Builder {
 ///     })
 /// }
 /// ```
-pub type BufResult<T, B> = (std::io::Result<T>, B);
+/// A specialized `Error` type for `io-uring` operations with buffers.
+#[derive(Debug)]
+pub struct BufError<B>(pub std::io::Error, pub B);
+
+impl<T> Display for BufError<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl<T: Debug> Error for BufError<T> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl<B> BufError<B> {
+    /// Applies a function to the contained buffer, returning a new `BufError`.
+    pub fn map<F, U>(self, f: F) -> BufError<U>
+    where
+        F: FnOnce(B) -> U,
+    {
+        BufError(self.0, f(self.1))
+    }
+}
+
 
 /// The simplest possible operation. Just posts a completion event, nothing else.
 ///

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -74,7 +74,7 @@ impl TcpStream {
     /// Read some data from the stream into the buffer.
     ///
     /// Returns the original buffer and quantity of data read.
-    pub async fn read<T: BoundedBufMut>(&self, buf: T) -> crate::BufResult<usize, T> {
+    pub async fn read<T: BoundedBufMut>(&self, buf: T) -> crate::Result<usize, T> {
         self.inner.read(buf).await
     }
 
@@ -91,7 +91,7 @@ impl TcpStream {
     /// In addition to errors that can be reported by `read`,
     /// this operation fails if the buffer is not registered in the
     /// current `tokio-uring` runtime.
-    pub async fn read_fixed<T>(&self, buf: T) -> crate::BufResult<usize, T>
+    pub async fn read_fixed<T>(&self, buf: T) -> crate::Result<usize, T>
     where
         T: BoundedBufMut<BufMut = FixedBuf>,
     {
@@ -155,7 +155,7 @@ impl TcpStream {
     /// ```
     ///
     /// [`write`]: Self::write
-    pub async fn write_all<T: BoundedBuf>(&self, buf: T) -> crate::BufResult<(), T> {
+    pub async fn write_all<T: BoundedBuf>(&self, buf: T) -> crate::Result<(), T> {
         self.inner.write_all(buf).await
     }
 
@@ -172,7 +172,7 @@ impl TcpStream {
     /// In addition to errors that can be reported by `write`,
     /// this operation fails if the buffer is not registered in the
     /// current `tokio-uring` runtime.
-    pub async fn write_fixed<T>(&self, buf: T) -> crate::BufResult<usize, T>
+    pub async fn write_fixed<T>(&self, buf: T) -> crate::Result<usize, T>
     where
         T: BoundedBuf<Buf = FixedBuf>,
     {
@@ -192,7 +192,7 @@ impl TcpStream {
     /// This function will return the first error that [`write_fixed`] returns.
     ///
     /// [`write_fixed`]: Self::write_fixed
-    pub async fn write_fixed_all<T>(&self, buf: T) -> crate::BufResult<(), T>
+    pub async fn write_fixed_all<T>(&self, buf: T) -> crate::Result<(), T>
     where
         T: BoundedBuf<Buf = FixedBuf>,
     {
@@ -222,7 +222,7 @@ impl TcpStream {
     /// written to this writer.
     ///
     /// [`Ok(n)`]: Ok
-    pub async fn writev<T: BoundedBuf>(&self, buf: Vec<T>) -> crate::BufResult<usize, Vec<T>> {
+    pub async fn writev<T: BoundedBuf>(&self, buf: Vec<T>) -> crate::Result<usize, Vec<T>> {
         self.inner.writev(buf).await
     }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -212,7 +212,7 @@ impl UdpSocket {
     /// Sends data on the connected socket
     ///
     /// On success, returns the number of bytes written.
-    pub async fn send<T: BoundedBuf>(&self, buf: T) -> crate::BufResult<usize, T> {
+    pub async fn send<T: BoundedBuf>(&self, buf: T) -> crate::Result<usize, T> {
         self.inner.send_to(buf, None).await
     }
 
@@ -223,7 +223,7 @@ impl UdpSocket {
         &self,
         buf: T,
         socket_addr: SocketAddr,
-    ) -> crate::BufResult<usize, T> {
+    ) -> crate::Result<usize, T> {
         self.inner.send_to(buf, Some(socket_addr)).await
     }
 
@@ -240,7 +240,7 @@ impl UdpSocket {
     /// > at writes over around 10 KB.
     ///
     /// Note: Using fixed buffers [#54](https://github.com/tokio-rs/tokio-uring/pull/54), avoids the page-pinning overhead
-    pub async fn send_zc<T: BoundedBuf>(&self, buf: T) -> crate::BufResult<usize, T> {
+    pub async fn send_zc<T: BoundedBuf>(&self, buf: T) -> crate::Result<usize, T> {
         self.inner.send_zc(buf).await
     }
 
@@ -299,7 +299,7 @@ impl UdpSocket {
     pub async fn recv_from<T: BoundedBufMut>(
         &self,
         buf: T,
-    ) -> crate::BufResult<(usize, SocketAddr), T> {
+    ) -> crate::Result<(usize, SocketAddr), T> {
         self.inner.recv_from(buf).await
     }
 
@@ -309,14 +309,14 @@ impl UdpSocket {
     pub async fn recvmsg<T: BoundedBufMut>(
         &self,
         buf: Vec<T>,
-    ) -> crate::BufResult<(usize, SocketAddr), Vec<T>> {
+    ) -> crate::Result<(usize, SocketAddr), Vec<T>> {
         self.inner.recvmsg(buf).await
     }
 
     /// Reads a packet of data from the socket into the buffer.
     ///
     /// Returns the original buffer and quantity of data read.
-    pub async fn read<T: BoundedBufMut>(&self, buf: T) -> crate::BufResult<usize, T> {
+    pub async fn read<T: BoundedBufMut>(&self, buf: T) -> crate::Result<usize, T> {
         self.inner.read(buf).await
     }
 
@@ -333,7 +333,7 @@ impl UdpSocket {
     /// In addition to errors that can be reported by `read`,
     /// this operation fails if the buffer is not registered in the
     /// current `tokio-uring` runtime.
-    pub async fn read_fixed<T>(&self, buf: T) -> crate::BufResult<usize, T>
+    pub async fn read_fixed<T>(&self, buf: T) -> crate::Result<usize, T>
     where
         T: BoundedBufMut<BufMut = FixedBuf>,
     {
@@ -360,7 +360,7 @@ impl UdpSocket {
     /// In addition to errors that can be reported by `write`,
     /// this operation fails if the buffer is not registered in the
     /// current `tokio-uring` runtime.
-    pub async fn write_fixed<T>(&self, buf: T) -> crate::BufResult<usize, T>
+    pub async fn write_fixed<T>(&self, buf: T) -> crate::Result<usize, T>
     where
         T: BoundedBuf<Buf = FixedBuf>,
     {

--- a/src/net/unix/stream.rs
+++ b/src/net/unix/stream.rs
@@ -75,7 +75,7 @@ impl UnixStream {
 
     /// Read some data from the stream into the buffer, returning the original buffer and
     /// quantity of data read.
-    pub async fn read<T: BoundedBufMut>(&self, buf: T) -> crate::BufResult<usize, T> {
+    pub async fn read<T: BoundedBufMut>(&self, buf: T) -> crate::Result<usize, T> {
         self.inner.read(buf).await
     }
 
@@ -90,7 +90,7 @@ impl UnixStream {
     /// In addition to errors that can be reported by `read`,
     /// this operation fails if the buffer is not registered in the
     /// current `tokio-uring` runtime.
-    pub async fn read_fixed<T>(&self, buf: T) -> crate::BufResult<usize, T>
+    pub async fn read_fixed<T>(&self, buf: T) -> crate::Result<usize, T>
     where
         T: BoundedBufMut<BufMut = FixedBuf>,
     {
@@ -116,7 +116,7 @@ impl UnixStream {
     /// This function will return the first error that [`write`] returns.
     ///
     /// [`write`]: Self::write
-    pub async fn write_all<T: BoundedBuf>(&self, buf: T) -> crate::BufResult<(), T> {
+    pub async fn write_all<T: BoundedBuf>(&self, buf: T) -> crate::Result<(), T> {
         self.inner.write_all(buf).await
     }
 
@@ -131,7 +131,7 @@ impl UnixStream {
     /// In addition to errors that can be reported by `write`,
     /// this operation fails if the buffer is not registered in the
     /// current `tokio-uring` runtime.
-    pub async fn write_fixed<T>(&self, buf: T) -> crate::BufResult<usize, T>
+    pub async fn write_fixed<T>(&self, buf: T) -> crate::Result<usize, T>
     where
         T: BoundedBuf<Buf = FixedBuf>,
     {
@@ -151,7 +151,7 @@ impl UnixStream {
     /// This function will return the first error that [`write_fixed`] returns.
     ///
     /// [`write_fixed`]: Self::write
-    pub async fn write_fixed_all<T>(&self, buf: T) -> crate::BufResult<(), T>
+    pub async fn write_fixed_all<T>(&self, buf: T) -> crate::Result<(), T>
     where
         T: BoundedBuf<Buf = FixedBuf>,
     {
@@ -182,7 +182,7 @@ impl UnixStream {
     /// written to this writer.
     ///
     /// [`Ok(n)`]: Ok
-    pub async fn writev<T: BoundedBuf>(&self, buf: Vec<T>) -> crate::BufResult<usize, Vec<T>> {
+    pub async fn writev<T: BoundedBuf>(&self, buf: Vec<T>) -> crate::Result<usize, Vec<T>> {
         self.inner.writev(buf).await
     }
 

--- a/tests/driver.rs
+++ b/tests/driver.rs
@@ -59,7 +59,6 @@ fn complete_ops_on_drop() {
                 25 * 1024 * 1024,
             )
             .await
-            .0
             .unwrap();
         })
         .await;
@@ -86,7 +85,6 @@ fn too_many_submissions() {
                 file.write_at(b"hello world".to_vec(), 0)
                     .submit()
                     .await
-                    .0
                     .unwrap();
             })
             .await;

--- a/tests/fixed_buf.rs
+++ b/tests/fixed_buf.rs
@@ -42,8 +42,7 @@ fn fixed_buf_turnaround() {
         // for another instance.
         assert!(buffers.check_out(0).is_none());
 
-        let (res, buf) = op.await;
-        let n = res.unwrap();
+        let (n, buf) = op.await.unwrap();
         assert_eq!(n, HELLO.len());
 
         // The buffer is owned by `buf`, can't check it out
@@ -81,12 +80,11 @@ fn unregister_invalidates_checked_out_buffers() {
         // The old buffer's index no longer matches the memory area of the
         // currently registered buffer, so the read operation using the old
         // buffer's memory should fail.
-        let (res, _) = file.read_fixed_at(fixed_buf, 0).await;
+        let res = file.read_fixed_at(fixed_buf, 0).await;
         assert_err!(res);
 
         let fixed_buf = buffers.check_out(0).unwrap();
-        let (res, buf) = file.read_fixed_at(fixed_buf, 0).await;
-        let n = res.unwrap();
+        let (n, buf) = file.read_fixed_at(fixed_buf, 0).await.unwrap();
         assert_eq!(n, HELLO.len());
         assert_eq!(&buf[..], HELLO);
     });
@@ -112,18 +110,17 @@ fn slicing() {
         let fixed_buf = buffers.check_out(0).unwrap();
 
         // Read no more than 8 bytes into the fixed buffer.
-        let (res, slice) = file.read_fixed_at(fixed_buf.slice(..8), 3).await;
-        let n = res.unwrap();
+        let (n, slice) = file.read_fixed_at(fixed_buf.slice(..8), 3).await.unwrap();
         assert_eq!(n, 8);
         assert_eq!(slice[..], HELLO[3..11]);
         let fixed_buf = slice.into_inner();
 
         // Write from the fixed buffer, starting at offset 1,
         // up to the end of the initialized bytes in the buffer.
-        let (res, slice) = file
+        let (n, slice) = file
             .write_fixed_at(fixed_buf.slice(1..), HELLO.len() as u64)
-            .await;
-        let n = res.unwrap();
+            .await
+            .unwrap();
         assert_eq!(n, 7);
         assert_eq!(slice[..], HELLO[4..11]);
         let fixed_buf = slice.into_inner();
@@ -131,8 +128,7 @@ fn slicing() {
         // Read into the fixed buffer, overwriting bytes starting from offset 3
         // and then extending the initialized part with as many bytes as
         // the operation can read.
-        let (res, slice) = file.read_fixed_at(fixed_buf.slice(3..), 0).await;
-        let n = res.unwrap();
+        let (n, slice) = file.read_fixed_at(fixed_buf.slice(3..), 0).await.unwrap();
         assert_eq!(n, HELLO.len() + 7);
         assert_eq!(slice[..HELLO.len()], HELLO[..]);
         assert_eq!(slice[HELLO.len()..], HELLO[4..11]);
@@ -167,8 +163,10 @@ fn pool_next_as_concurrency_limit() {
                 let file = File::from_std(cloned_file);
                 let data = [b'0' + i as u8; BUF_SIZE];
                 buf.put_slice(&data);
-                let (res, buf) = file.write_fixed_all_at(buf, BUF_SIZE as u64 * i).await;
-                res.unwrap();
+                let (_, buf) = file
+                    .write_fixed_all_at(buf, BUF_SIZE as u64 * i)
+                    .await
+                    .unwrap();
                 println!("[worker {}]: dropping buffer {}", i, buf.buf_index());
             });
 


### PR DESCRIPTION
This PR is a update of #267, which seems to have gone stale, due to inactivity on in this repo.

Changes the return type to be a Result of tuples, instead of a tuple containing a result and a buffer. This allows this crate to work in a more ergenomic fashion with `?` operator

In addition to updating the original PR, the following changes are made in this one, not in the original

- `BufError` renamed `Error`. This follows the more usual convention of using crate prefixes to qualify error types, rather than the type name itself.
- `BufResult` renamed `Result`. This is the same rational
- `map_buf` helper function implrmented with a sealed trait, to give method calling convention, rather than qualified calls
 


