### PR TITLE
chore: prepare v0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tokio-uring"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 edition = "2018"
 readme = "README.md"
 license = "MIT"
-documentation = "https://docs.rs/tokio-uring/0.4.0/tokio-uring"
+documentation = "https://docs.rs/tokio-uring/0.5.0/tokio-uring"
 repository = "https://github.com/tokio-rs/tokio-uring"
 homepage = "https://tokio.rs"
 description = """

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ runtime internally manages the main Tokio runtime and a `io-uring` driver.
 In your Cargo.toml:
 ```toml
 [dependencies]
-tokio-uring = { version = "0.4.0" }
+tokio-uring = { version = "0.5.0" }
 ```
 In your main.rs:
 ```rust


### PR DESCRIPTION
The changelog for this release will be generated, and thus is not included here.