### PR TITLE
Fix clippy warnings

### DIFF
--- a/benches/lai/no_op.rs
+++ b/benches/lai/no_op.rs
@@ -60,20 +60,26 @@ fn no_op_x1() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn no_op_x32() -> Result<(), Box<dyn std::error::Error>> {
-    let mut opts = Options::default();
-    opts.concurrency = 32;
+    let opts = Options {
+        concurrency: 32,
+        ..Options::default()
+    };
     run_no_ops(black_box(opts))
 }
 
 fn no_op_x64() -> Result<(), Box<dyn std::error::Error>> {
-    let mut opts = Options::default();
-    opts.concurrency = 64;
+    let opts = Options {
+        concurrency: 64,
+        ..Options::default()
+    };
     run_no_ops(black_box(opts))
 }
 
 fn no_op_x256() -> Result<(), Box<dyn std::error::Error>> {
-    let mut opts = Options::default();
-    opts.concurrency = 256;
+    let opts = Options {
+        concurrency: 256,
+        ..Options::default()
+    };
     run_no_ops(black_box(opts))
 }
 

--- a/src/io/noop.rs
+++ b/src/io/noop.rs
@@ -32,7 +32,7 @@ mod test {
     use crate as tokio_uring;
 
     #[test]
-    fn perform_no_op() -> () {
+    fn perform_no_op() {
         tokio_uring::start(async {
             tokio_uring::no_op().await.unwrap();
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //! call `close()`.
 
 #![warn(missing_docs)]
-#![allow(clippy::thread_local_initializer_can_be_made_const)]
+#![allow(clippy::missing_const_for_thread_local)]
 
 macro_rules! syscall {
     ($fn: ident ( $($arg: expr),* $(,)* ) ) => {{

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -177,13 +177,13 @@ mod test {
     #[test]
     fn block_on() {
         let rt = Runtime::new(&builder()).unwrap();
-        rt.block_on(async move { () });
+        rt.block_on(async move {});
     }
 
     #[test]
     fn block_on_twice() {
         let rt = Runtime::new(&builder()).unwrap();
-        rt.block_on(async move { () });
-        rt.block_on(async move { () });
+        rt.block_on(async move {});
+        rt.block_on(async move {});
     }
 }

--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -148,7 +148,8 @@ fn explicit_close() {
 fn drop_open() {
     tokio_uring::start(async {
         let tempfile = tempfile();
-        let _ = File::create(tempfile.path());
+        // Explicitly not awaiting the future
+        _ = File::create(tempfile.path());
 
         // Do something else
         let file = File::create(tempfile.path()).await.unwrap();


### PR DESCRIPTION
Clippy had some suggestions so I followed them.

One thing that is still left over which I am unsure about is an unused concurrency variable inside the `lai` benchmark. It was originally added in #144 but then in #151 it was reworked a bit and the concurrency variable became unused.

That means that currently, the `no_op_x{num}` lai benchmarks are all identical.