### PR TITLE
Switch from io_uring to rustix_uring for broad compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ keywords = ["async", "fs", "io-uring"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.2", features = ["net", "rt", "sync"] }
-slab = "0.4.2"
+tokio = { version = "1.12", features = ["net", "rt", "sync"] }
+slab = "0.4.4"
 libc = "0.2.80"
-io-uring = "0.6.0"
+rustix = { version = "0.38.42", features = ["net", "io_uring"] }
+rustix-uring = "0.2.0"
 socket2 = { version = "0.4.4", features = ["all"] }
 bytes = { version = "1.0", optional = true }
 futures-util = { version = "0.3.26", default-features = false, features = ["std"] }

--- a/examples/test_create_dir_all.rs
+++ b/examples/test_create_dir_all.rs
@@ -1,3 +1,4 @@
+use rustix::fs::StatxFlags;
 use std::io;
 use std::path::Path;
 use tokio_uring::fs;
@@ -200,7 +201,7 @@ async fn statx_builder2<P: AsRef<Path>>(dir_path: P, rel_path: P) -> io::Result<
 
 async fn matches_mode<P: AsRef<Path>>(path: P, want_mode: u16) -> io::Result<()> {
     let statx = tokio_uring::fs::StatxBuilder::new()
-        .mask(libc::STATX_MODE)
+        .mask(StatxFlags::MODE)
         .pathname(path)?
         .statx()
         .await?;

--- a/src/buf/fixed/buffers.rs
+++ b/src/buf/fixed/buffers.rs
@@ -1,4 +1,4 @@
-use libc::iovec;
+use rustix::io_uring::iovec;
 
 // Abstracts management of fixed buffers in a buffer registry.
 pub(crate) trait FixedBuffers {

--- a/src/buf/fixed/handle.rs
+++ b/src/buf/fixed/handle.rs
@@ -1,7 +1,7 @@
 use super::FixedBuffers;
 use crate::buf::{IoBuf, IoBufMut};
 
-use libc::iovec;
+use rustix::io_uring::iovec;
 use std::cell::RefCell;
 use std::fmt::{self, Debug};
 use std::ops::{Deref, DerefMut};

--- a/src/buf/fixed/plumbing/pool.rs
+++ b/src/buf/fixed/plumbing/pool.rs
@@ -1,7 +1,8 @@
 use crate::buf::fixed::{handle::CheckedOutBuf, FixedBuffers};
 use crate::buf::IoBufMut;
 
-use libc::{iovec, UIO_MAXIOV};
+use libc::UIO_MAXIOV;
+use rustix::io_uring::iovec;
 use tokio::sync::Notify;
 
 use std::cmp;

--- a/src/buf/fixed/plumbing/registry.rs
+++ b/src/buf/fixed/plumbing/registry.rs
@@ -1,7 +1,8 @@
 use crate::buf::fixed::{handle::CheckedOutBuf, FixedBuffers};
 use crate::buf::IoBufMut;
 
-use libc::{iovec, UIO_MAXIOV};
+use libc::UIO_MAXIOV;
+use rustix::io_uring::iovec;
 use std::cmp;
 use std::mem;
 use std::ptr;

--- a/src/fs/create_dir_all.rs
+++ b/src/fs/create_dir_all.rs
@@ -1,4 +1,5 @@
 use futures_util::future::LocalBoxFuture;
+use rustix::fs::StatxFlags;
 use std::io;
 use std::path::Path;
 
@@ -165,17 +166,17 @@ impl DirBuilder {
 
 mod fs_imp {
     use crate::runtime::driver::op::Op;
-    use libc::mode_t;
+    use rustix::fs::Mode;
     use std::path::Path;
 
     #[derive(Debug)]
     pub struct DirBuilder {
-        mode: mode_t,
+        mode: Mode,
     }
 
     impl DirBuilder {
         pub fn new() -> DirBuilder {
-            DirBuilder { mode: 0o777 }
+            DirBuilder { mode: 0o777.into() }
         }
 
         pub async fn mkdir(&self, p: &Path) -> std::io::Result<()> {
@@ -183,7 +184,7 @@ mod fs_imp {
         }
 
         pub fn set_mode(&mut self, mode: u32) {
-            self.mode = mode as mode_t;
+            self.mode = mode.into();
         }
     }
 }
@@ -193,7 +194,7 @@ mod fs_imp {
 // Uses one asynchronous uring call to determine this.
 async fn is_dir<P: AsRef<Path>>(path: P) -> bool {
     let mut builder = crate::fs::StatxBuilder::new();
-    if builder.mask(libc::STATX_TYPE).pathname(path).is_err() {
+    if builder.mask(StatxFlags::TYPE).pathname(path).is_err() {
         return false;
     }
 

--- a/src/fs/directory.rs
+++ b/src/fs/directory.rs
@@ -31,7 +31,7 @@ use std::path::Path;
 /// }
 /// ```
 pub async fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    Op::make_dir(path.as_ref(), 0o777)?.await
+    Op::make_dir(path.as_ref(), 0o777.into())?.await
 }
 
 /// Removes a directory on the local filesystem.

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -1,3 +1,5 @@
+use rustix_uring::types;
+
 use crate::buf::fixed::FixedBuf;
 use crate::buf::{BoundedBuf, BoundedBufMut, IoBuf, IoBufMut, Slice};
 use crate::fs::OpenOptions;
@@ -960,5 +962,5 @@ pub async fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// }
 /// ```
 pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> {
-    Op::rename_at(from.as_ref(), to.as_ref(), 0)?.await
+    Op::rename_at(from.as_ref(), to.as_ref(), types::RenameFlags::empty())?.await
 }

--- a/src/io/accept.rs
+++ b/src/io/accept.rs
@@ -1,3 +1,5 @@
+use rustix::net::SocketFlags;
+
 use crate::io::{SharedFd, Socket};
 use crate::runtime::driver::op;
 use crate::runtime::driver::op::{Completable, Op};
@@ -12,7 +14,7 @@ pub(crate) struct Accept {
 
 impl Op<Accept> {
     pub(crate) fn accept(fd: &SharedFd) -> io::Result<Op<Accept>> {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
 
         let socketaddr = Box::new((
             unsafe { std::mem::zeroed() },
@@ -30,7 +32,7 @@ impl Op<Accept> {
                         &mut accept.socketaddr.0 as *mut _ as *mut _,
                         &mut accept.socketaddr.1,
                     )
-                    .flags(libc::O_CLOEXEC)
+                    .flags(SocketFlags::CLOEXEC)
                     .build()
                 },
             )

--- a/src/io/close.rs
+++ b/src/io/close.rs
@@ -10,7 +10,7 @@ pub(crate) struct Close {
 
 impl Op<Close> {
     pub(crate) fn close(fd: RawFd) -> io::Result<Op<Close>> {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
 
         CONTEXT.with(|x| {
             x.handle()

--- a/src/io/connect.rs
+++ b/src/io/connect.rs
@@ -15,7 +15,7 @@ pub(crate) struct Connect {
 impl Op<Connect> {
     /// Submit a request to connect.
     pub(crate) fn connect(fd: &SharedFd, socket_addr: SockAddr) -> io::Result<Op<Connect>> {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
 
         CONTEXT.with(|x| {
             x.handle().expect("Not in a runtime context").submit_op(
@@ -26,7 +26,7 @@ impl Op<Connect> {
                 |connect| {
                     opcode::Connect::new(
                         types::Fd(connect.fd.raw_fd()),
-                        connect.socket_addr.as_ptr(),
+                        connect.socket_addr.as_ptr() as *const _,
                         connect.socket_addr.len(),
                     )
                     .build()

--- a/src/io/fallocate.rs
+++ b/src/io/fallocate.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use io_uring::{opcode, types};
+use rustix_uring::{opcode, types};
 
 use crate::{
     io::SharedFd,

--- a/src/io/fsync.rs
+++ b/src/io/fsync.rs
@@ -3,7 +3,7 @@ use std::io;
 use crate::io::SharedFd;
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
-use io_uring::{opcode, types};
+use rustix_uring::{opcode, types};
 
 pub(crate) struct Fsync {
     fd: SharedFd,

--- a/src/io/mkdir_at.rs
+++ b/src/io/mkdir_at.rs
@@ -15,8 +15,8 @@ pub(crate) struct Mkdir {
 
 impl Op<Mkdir> {
     /// Submit a request to create a directory
-    pub(crate) fn make_dir(path: &Path, mode: u32) -> io::Result<Op<Mkdir>> {
-        use io_uring::{opcode, types};
+    pub(crate) fn make_dir(path: &Path, mode: rustix::fs::Mode) -> io::Result<Op<Mkdir>> {
+        use rustix_uring::{opcode, types};
 
         let _path = cstr(path)?;
 

--- a/src/io/noop.rs
+++ b/src/io/noop.rs
@@ -9,7 +9,7 @@ pub struct NoOp {}
 
 impl Op<NoOp> {
     pub fn no_op() -> io::Result<Op<NoOp>> {
-        use io_uring::opcode;
+        use rustix_uring::opcode;
 
         CONTEXT.with(|x| {
             x.handle()

--- a/src/io/open.rs
+++ b/src/io/open.rs
@@ -1,3 +1,5 @@
+use rustix_uring::types::OFlags;
+
 use crate::fs::{File, OpenOptions};
 use crate::io::SharedFd;
 
@@ -11,18 +13,18 @@ use std::path::Path;
 #[allow(dead_code)]
 pub(crate) struct Open {
     pub(crate) path: CString,
-    pub(crate) flags: libc::c_int,
+    pub(crate) flags: OFlags,
 }
 
 impl Op<Open> {
     /// Submit a request to open a file.
     pub(crate) fn open(path: &Path, options: &OpenOptions) -> io::Result<Op<Open>> {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
         let path = super::util::cstr(path)?;
-        let flags = libc::O_CLOEXEC
+        let flags = OFlags::CLOEXEC
             | options.access_mode()?
             | options.creation_mode()?
-            | (options.custom_flags & !libc::O_ACCMODE);
+            | (options.custom_flags & !OFlags::ACCMODE);
 
         CONTEXT.with(|x| {
             x.handle()

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -18,7 +18,7 @@ pub(crate) struct Read<T> {
 
 impl<T: BoundedBufMut> Op<Read<T>> {
     pub(crate) fn read_at(fd: &SharedFd, buf: T, offset: u64) -> io::Result<Op<Read<T>>> {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
 
         CONTEXT.with(|x| {
             x.handle().expect("Not in a runtime context").submit_op(

--- a/src/io/read_fixed.rs
+++ b/src/io/read_fixed.rs
@@ -26,7 +26,7 @@ where
         buf: T,
         offset: u64,
     ) -> io::Result<Op<ReadFixed<T>>> {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
 
         CONTEXT.with(|x| {
             x.handle().expect("Not in a runtime context").submit_op(

--- a/src/io/readv.rs
+++ b/src/io/readv.rs
@@ -4,7 +4,7 @@ use crate::BufResult;
 use crate::io::SharedFd;
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
-use libc::iovec;
+use rustix_uring::types::iovec;
 use std::io;
 
 pub(crate) struct Readv<T> {
@@ -25,7 +25,7 @@ impl<T: BoundedBufMut> Op<Readv<T>> {
         mut bufs: Vec<T>,
         offset: u64,
     ) -> io::Result<Op<Readv<T>>> {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
 
         // Build `iovec` objects referring the provided `bufs` for `io_uring::opcode::Readv`.
         let iovs: Vec<iovec> = bufs

--- a/src/io/recv_from.rs
+++ b/src/io/recv_from.rs
@@ -1,6 +1,7 @@
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
 use crate::{buf::BoundedBufMut, io::SharedFd, BufResult};
+use rustix::io_uring::msghdr;
 use socket2::SockAddr;
 use std::{
     io::IoSliceMut,
@@ -13,12 +14,12 @@ pub(crate) struct RecvFrom<T> {
     pub(crate) buf: T,
     io_slices: Vec<IoSliceMut<'static>>,
     pub(crate) socket_addr: Box<SockAddr>,
-    pub(crate) msghdr: Box<libc::msghdr>,
+    pub(crate) msghdr: Box<msghdr>,
 }
 
 impl<T: BoundedBufMut> Op<RecvFrom<T>> {
     pub(crate) fn recv_from(fd: &SharedFd, mut buf: T) -> io::Result<Op<RecvFrom<T>>> {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
 
         let mut io_slices = vec![IoSliceMut::new(unsafe {
             std::slice::from_raw_parts_mut(buf.stable_mut_ptr(), buf.bytes_total())
@@ -26,11 +27,11 @@ impl<T: BoundedBufMut> Op<RecvFrom<T>> {
 
         let socket_addr = Box::new(unsafe { SockAddr::init(|_, _| Ok(()))?.1 });
 
-        let mut msghdr: Box<libc::msghdr> = Box::new(unsafe { std::mem::zeroed() });
+        let mut msghdr: Box<msghdr> = Box::new(unsafe { std::mem::zeroed() });
         msghdr.msg_iov = io_slices.as_mut_ptr().cast();
         msghdr.msg_iovlen = io_slices.len() as _;
         msghdr.msg_name = socket_addr.as_ptr() as *mut libc::c_void;
-        msghdr.msg_namelen = socket_addr.len();
+        msghdr.msg_namelen = socket_addr.len() as _;
 
         CONTEXT.with(|x| {
             x.handle().expect("Not in a runtime context").submit_op(

--- a/src/io/rename_at.rs
+++ b/src/io/rename_at.rs
@@ -1,3 +1,5 @@
+use rustix_uring::types::RenameFlags;
+
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
 use std::ffi::CString;
@@ -16,8 +18,12 @@ pub(crate) struct RenameAt {
 impl Op<RenameAt> {
     /// Submit a request to rename a specified path to a new name with
     /// the provided flags.
-    pub(crate) fn rename_at(from: &Path, to: &Path, flags: u32) -> io::Result<Op<RenameAt>> {
-        use io_uring::{opcode, types};
+    pub(crate) fn rename_at(
+        from: &Path,
+        to: &Path,
+        flags: RenameFlags,
+    ) -> io::Result<Op<RenameAt>> {
+        use rustix_uring::{opcode, types};
 
         let from = super::util::cstr(from)?;
         let to = super::util::cstr(to)?;

--- a/src/io/send_to.rs
+++ b/src/io/send_to.rs
@@ -3,6 +3,7 @@ use crate::io::SharedFd;
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
 use crate::BufResult;
+use rustix::io_uring::msghdr;
 use socket2::SockAddr;
 use std::io::IoSlice;
 use std::{boxed::Box, io, net::SocketAddr};
@@ -15,7 +16,7 @@ pub(crate) struct SendTo<T> {
     io_slices: Vec<IoSlice<'static>>,
     #[allow(dead_code)]
     socket_addr: Option<Box<SockAddr>>,
-    pub(crate) msghdr: Box<libc::msghdr>,
+    pub(crate) msghdr: Box<msghdr>,
 }
 
 impl<T: BoundedBuf> Op<SendTo<T>> {
@@ -24,13 +25,13 @@ impl<T: BoundedBuf> Op<SendTo<T>> {
         buf: T,
         socket_addr: Option<SocketAddr>,
     ) -> io::Result<Op<SendTo<T>>> {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
 
         let io_slices = vec![IoSlice::new(unsafe {
             std::slice::from_raw_parts(buf.stable_ptr(), buf.bytes_init())
         })];
 
-        let mut msghdr: Box<libc::msghdr> = Box::new(unsafe { std::mem::zeroed() });
+        let mut msghdr: Box<msghdr> = Box::new(unsafe { std::mem::zeroed() });
         msghdr.msg_iov = io_slices.as_ptr() as *mut _;
         msghdr.msg_iovlen = io_slices.len() as _;
 
@@ -38,7 +39,7 @@ impl<T: BoundedBuf> Op<SendTo<T>> {
             Some(_socket_addr) => {
                 let socket_addr = Box::new(SockAddr::from(_socket_addr));
                 msghdr.msg_name = socket_addr.as_ptr() as *mut libc::c_void;
-                msghdr.msg_namelen = socket_addr.len();
+                msghdr.msg_namelen = socket_addr.len() as _;
                 Some(socket_addr)
             }
             None => {

--- a/src/io/send_zc.rs
+++ b/src/io/send_zc.rs
@@ -17,7 +17,7 @@ pub(crate) struct SendZc<T> {
 
 impl<T: BoundedBuf> Op<SendZc<T>, MultiCQEFuture> {
     pub(crate) fn send_zc(fd: &SharedFd, buf: T) -> io::Result<Self> {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
 
         CONTEXT.with(|x| {
             x.handle().expect("Not in a runtime context").submit_op(

--- a/src/io/socket.rs
+++ b/src/io/socket.rs
@@ -6,6 +6,7 @@ use crate::{
     io::SharedFd,
     UnsubmittedOneshot,
 };
+use rustix::fd::BorrowedFd;
 use std::{
     io,
     net::SocketAddr,
@@ -254,7 +255,7 @@ impl Socket {
     }
 
     pub(crate) fn listen(&self, backlog: libc::c_int) -> io::Result<()> {
-        syscall!(listen(self.as_raw_fd(), backlog))?;
+        rustix::net::listen(unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }, backlog)?;
         Ok(())
     }
 

--- a/src/io/symlink.rs
+++ b/src/io/symlink.rs
@@ -17,7 +17,7 @@ impl Op<Symlink> {
         from: P,
         to: Q,
     ) -> io::Result<Op<Symlink>> {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
 
         let _from = cstr(from.as_ref())?;
         let _to = cstr(to.as_ref())?;

--- a/src/io/unlink_at.rs
+++ b/src/io/unlink_at.rs
@@ -1,3 +1,5 @@
+use rustix_uring::types::AtFlags;
+
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
 use std::ffi::CString;
@@ -12,17 +14,17 @@ pub(crate) struct Unlink {
 impl Op<Unlink> {
     /// Submit a request to unlink a directory with provided flags.
     pub(crate) fn unlink_dir(path: &Path) -> io::Result<Op<Unlink>> {
-        Self::unlink(path, libc::AT_REMOVEDIR)
+        Self::unlink(path, AtFlags::REMOVEDIR)
     }
 
     /// Submit a request to unlink a file with provided flags.
     pub(crate) fn unlink_file(path: &Path) -> io::Result<Op<Unlink>> {
-        Self::unlink(path, 0)
+        Self::unlink(path, AtFlags::empty())
     }
 
     /// Submit a request to unlink a specified path with provided flags.
-    pub(crate) fn unlink(path: &Path, flags: i32) -> io::Result<Op<Unlink>> {
-        use io_uring::{opcode, types};
+    pub(crate) fn unlink(path: &Path, flags: AtFlags) -> io::Result<Op<Unlink>> {
+        use rustix_uring::{opcode, types};
 
         let path = super::util::cstr(path)?;
 

--- a/src/io/write.rs
+++ b/src/io/write.rs
@@ -1,5 +1,5 @@
 use crate::{buf::BoundedBuf, io::SharedFd, BufResult, OneshotOutputTransform, UnsubmittedOneshot};
-use io_uring::cqueue::Entry;
+use rustix_uring::cqueue::Entry;
 use std::io;
 use std::marker::PhantomData;
 
@@ -37,7 +37,7 @@ impl<T> OneshotOutputTransform for WriteTransform<T> {
 
 impl<T: BoundedBuf> UnsubmittedWrite<T> {
     pub(crate) fn write_at(fd: &SharedFd, buf: T, offset: u64) -> Self {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
 
         // Get raw buffer info
         let ptr = buf.stable_ptr();

--- a/src/io/write_fixed.rs
+++ b/src/io/write_fixed.rs
@@ -25,7 +25,7 @@ where
         buf: T,
         offset: u64,
     ) -> io::Result<Op<WriteFixed<T>>> {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
 
         CONTEXT.with(|x| {
             x.handle().expect("Not in a runtime context").submit_op(

--- a/src/io/writev.rs
+++ b/src/io/writev.rs
@@ -1,7 +1,8 @@
+use rustix::io_uring::iovec;
+
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
 use crate::{buf::BoundedBuf, io::SharedFd, BufResult};
-use libc::iovec;
 use std::io;
 
 pub(crate) struct Writev<T> {
@@ -22,7 +23,7 @@ impl<T: BoundedBuf> Op<Writev<T>> {
         mut bufs: Vec<T>,
         offset: u64,
     ) -> io::Result<Op<Writev<T>>> {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
 
         // Build `iovec` objects referring the provided `bufs` for `io_uring::opcode::Readv`.
         let iovs: Vec<iovec> = bufs

--- a/src/io/writev_all.rs
+++ b/src/io/writev_all.rs
@@ -1,7 +1,7 @@
 use crate::runtime::driver::op::{Completable, CqeResult, Op};
 use crate::runtime::CONTEXT;
 use crate::{buf::BoundedBuf, io::SharedFd};
-use libc::iovec;
+use rustix::io_uring::iovec;
 use std::io;
 
 // This provides a common write-all implementation for writev and is fairly efficient by allocating
@@ -126,7 +126,7 @@ impl<T: BoundedBuf> Op<WritevAll<T>> {
         iovs_len: u32,
         offset: u64,
     ) -> io::Result<Op<WritevAll<T>>> {
-        use io_uring::{opcode, types};
+        use rustix_uring::{opcode, types};
 
         CONTEXT.with(|x| {
             x.handle().expect("Not in a runtime context").submit_op(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,17 +59,6 @@
 #![warn(missing_docs)]
 #![allow(clippy::thread_local_initializer_can_be_made_const)]
 
-macro_rules! syscall {
-    ($fn: ident ( $($arg: expr),* $(,)* ) ) => {{
-        let res = unsafe { libc::$fn($($arg, )*) };
-        if res == -1 {
-            Err(std::io::Error::last_os_error())
-        } else {
-            Ok(res)
-        }
-    }};
-}
-
 #[macro_use]
 mod future;
 mod io;
@@ -155,8 +144,8 @@ pub fn start<F: Future>(future: F) -> F::Output {
 /// This function is provided to avoid requiring the user of this crate from
 /// having to use the io_uring crate as well. Refer to Builder::start example
 /// for its intended usage.
-pub fn uring_builder() -> io_uring::Builder {
-    io_uring::IoUring::builder()
+pub fn uring_builder() -> rustix_uring::Builder {
+    rustix_uring::IoUring::builder()
 }
 
 /// Builder API that can create and start the `io_uring` runtime with non-default parameters,
@@ -164,7 +153,7 @@ pub fn uring_builder() -> io_uring::Builder {
 // #[derive(Clone, Default)]
 pub struct Builder {
     entries: u32,
-    urb: io_uring::Builder,
+    urb: rustix_uring::Builder,
 }
 
 /// Constructs a [`Builder`] with default settings.
@@ -176,7 +165,7 @@ pub struct Builder {
 pub fn builder() -> Builder {
     Builder {
         entries: 256,
-        urb: io_uring::IoUring::builder(),
+        urb: rustix_uring::IoUring::builder(),
     }
 }
 
@@ -196,7 +185,7 @@ impl Builder {
     /// inner `io_uring` API.
     ///
     /// Refer to the [`io_uring::Builder`] documentation for all the supported methods.
-    pub fn uring_builder(&mut self, b: &io_uring::Builder) -> &mut Self {
+    pub fn uring_builder(&mut self, b: &rustix_uring::Builder) -> &mut Self {
         self.urb = b.clone();
         self
     }

--- a/src/runtime/driver/handle.rs
+++ b/src/runtime/driver/handle.rs
@@ -12,7 +12,7 @@
 //! The weak handle should be used by anything which is stored in the driver or does not need to
 //! keep the driver alive for it's duration.
 
-use io_uring::{cqueue, squeue};
+use rustix_uring::{cqueue, squeue};
 use std::cell::RefCell;
 use std::io;
 use std::ops::Deref;
@@ -45,7 +45,7 @@ impl Handle {
         self.inner.borrow_mut().dispatch_completions()
     }
 
-    pub(crate) fn flush(&self) -> io::Result<usize> {
+    pub(crate) fn flush(&self) -> rustix_uring::Result<usize> {
         self.inner.borrow_mut().uring.submit()
     }
 


### PR DESCRIPTION
rustix wraps syscalls without the libc crate, which does not expose a bunch of io-uring related APIs such as statx on musl targets.

With these changes, tokio-uring compiles fine when built for musl targets.

TODO: test and split the minvers fixes + maybe split the change for the listen syscall into their own commits