### PR TITLE
General cleanup - update dependencies & remove broken/redundant tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.43", features = ["net", "rt", "sync"] }
 slab = "0.4.2"
 libc = "0.2.80"
 io-uring = "0.7.4"
-socket2 = { version = "0.4.4", features = ["all"] }
+socket2 = { version = "0.5.8", features = ["all"] }
 bytes = { version = "1.0", optional = true }
 futures-util = { version = "0.3.26", default-features = false, features = ["std"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ keywords = ["async", "fs", "io-uring"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.2", features = ["net", "rt", "sync"] }
+tokio = { version = "1.43", features = ["net", "rt", "sync"] }
 slab = "0.4.2"
 libc = "0.2.80"
-io-uring = "0.6.0"
+io-uring = "0.7.4"
 socket2 = { version = "0.4.4", features = ["all"] }
 bytes = { version = "1.0", optional = true }
 futures-util = { version = "0.3.26", default-features = false, features = ["std"] }
@@ -29,10 +29,10 @@ futures-util = { version = "0.3.26", default-features = false, features = ["std"
 tempfile = "3.2.0"
 tokio-test = "0.4.2"
 iai = "0.1.1"
-criterion = "0.4.0"
+criterion = "0.5.1"
 # we use joinset in our tests
 tokio = "1.21.2"
-nix = "0.26.1"
+nix = "0.29.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,13 @@ bytes = { version = "1.0", optional = true }
 futures-util = { version = "0.3.26", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-tempfile = "3.2.0"
+tempfile = "3.17.0"
 tokio-test = "0.4.2"
 iai = "0.1.1"
 criterion = "0.5.1"
 # we use joinset in our tests
 tokio = "1.21.2"
-nix = "0.29.0"
+nix = { version = "0.29.0", features = ["resource"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/io/accept.rs
+++ b/src/io/accept.rs
@@ -46,7 +46,7 @@ impl Completable for Accept {
         let fd = SharedFd::new(fd as i32);
         let socket = Socket { fd };
         let (_, addr) = unsafe {
-            socket2::SockAddr::init(move |addr_storage, len| {
+            socket2::SockAddr::try_init(move |addr_storage, len| {
                 self.socketaddr.0.clone_into(&mut *addr_storage);
                 *len = self.socketaddr.1;
                 Ok(())

--- a/src/io/recv_from.rs
+++ b/src/io/recv_from.rs
@@ -24,7 +24,7 @@ impl<T: BoundedBufMut> Op<RecvFrom<T>> {
             std::slice::from_raw_parts_mut(buf.stable_mut_ptr(), buf.bytes_total())
         })];
 
-        let socket_addr = Box::new(unsafe { SockAddr::init(|_, _| Ok(()))?.1 });
+        let socket_addr = Box::new(unsafe { SockAddr::try_init(|_, _| Ok(()))?.1 });
 
         let mut msghdr: Box<libc::msghdr> = Box::new(unsafe { std::mem::zeroed() });
         msghdr.msg_iov = io_slices.as_mut_ptr().cast();

--- a/src/io/recvmsg.rs
+++ b/src/io/recvmsg.rs
@@ -28,7 +28,7 @@ impl<T: BoundedBufMut> Op<RecvMsg<T>> {
             }));
         }
 
-        let socket_addr = Box::new(unsafe { SockAddr::init(|_, _| Ok(()))?.1 });
+        let socket_addr = Box::new(unsafe { SockAddr::try_init(|_, _| Ok(()))?.1 });
 
         let mut msghdr: Box<libc::msghdr> = Box::new(unsafe { std::mem::zeroed() });
         msghdr.msg_iov = io_slices.as_mut_ptr().cast();

--- a/src/io/socket.rs
+++ b/src/io/socket.rs
@@ -9,7 +9,7 @@ use crate::{
 use std::{
     io,
     net::SocketAddr,
-    os::unix::io::{AsRawFd, IntoRawFd, RawFd},
+    os::unix::io::{AsFd, AsRawFd, IntoRawFd, RawFd, BorrowedFd},
     path::Path,
 };
 
@@ -283,5 +283,13 @@ impl Socket {
 impl AsRawFd for Socket {
     fn as_raw_fd(&self) -> RawFd {
         self.fd.raw_fd()
+    }
+}
+
+impl AsFd for Socket {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe {
+            BorrowedFd::borrow_raw(self.fd.raw_fd())
+        } 
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //! call `close()`.
 
 #![warn(missing_docs)]
-#![allow(clippy::thread_local_initializer_can_be_made_const)]
+#![allow(clippy::missing_const_for_thread_local)]
 
 macro_rules! syscall {
     ($fn: ident ( $($arg: expr),* $(,)* ) ) => {{

--- a/src/runtime/driver/op/slab_list.rs
+++ b/src/runtime/driver/op/slab_list.rs
@@ -111,7 +111,7 @@ impl<'a, T> SlabList<'a, T> {
     }
 }
 
-impl<'a, T> Drop for SlabList<'a, T> {
+impl<T> Drop for SlabList<'_, T> {
     fn drop(&mut self) {
         while !self.is_empty() {
             let removed = self.slab.remove(self.index.start);
@@ -120,7 +120,7 @@ impl<'a, T> Drop for SlabList<'a, T> {
     }
 }
 
-impl<'a, T> Iterator for SlabList<'a, T> {
+impl<T> Iterator for SlabList<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -130,21 +130,6 @@ fn cancel_read() {
 }
 
 #[test]
-fn explicit_close() {
-    let mut tempfile = tempfile();
-    tempfile.write_all(HELLO).unwrap();
-
-    tokio_uring::start(async {
-        let file = File::open(tempfile.path()).await.unwrap();
-        let fd = file.as_raw_fd();
-
-        file.close().await.unwrap();
-
-        assert_invalid_fd(fd);
-    })
-}
-
-#[test]
 fn drop_open() {
     tokio_uring::start(async {
         let tempfile = tempfile();
@@ -158,19 +143,6 @@ fn drop_open() {
         let file = std::fs::read(tempfile.path()).unwrap();
         assert_eq!(file, HELLO);
     });
-}
-
-#[test]
-fn drop_off_runtime() {
-    let file = tokio_uring::start(async {
-        let tempfile = tempfile();
-        File::open(tempfile.path()).await.unwrap()
-    });
-
-    let fd = file.as_raw_fd();
-    drop(file);
-
-    assert_invalid_fd(fd);
 }
 
 #[test]
@@ -330,16 +302,4 @@ async fn poll_once(future: impl std::future::Future) {
         Poll::Ready(())
     })
     .await;
-}
-
-fn assert_invalid_fd(fd: RawFd) {
-    use std::fs::File;
-
-    let mut f = unsafe { File::from_raw_fd(fd) };
-    let mut buf = vec![];
-
-    match f.read_to_end(&mut buf) {
-        Err(ref e) if e.raw_os_error() == Some(libc::EBADF) => {}
-        res => panic!("assert_invalid_fd finds for fd {:?}, res = {:?}", fd, res),
-    }
 }


### PR DESCRIPTION
This pr updates a few dependencies, applies some new clippy suggestions and removes a couple of tests. The tests which have been removed cause a runtime error with newer versions of rust due to new safety checks which were enabled with [https://github.com/rust-lang/rust/pull/124210](https://github.com/rust-lang/rust/pull/124210).