### PR TITLE
chore: Update dependencies and fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ iai = "0.1.1"
 criterion = "0.5.1"
 # we use joinset in our tests
 tokio = "1.44.2"
-nix = "0.29.0"
+nix = { version = "0.29.0", features = ["resource"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,22 +17,22 @@ keywords = ["async", "fs", "io-uring"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.2", features = ["net", "rt", "sync"] }
-slab = "0.4.2"
-libc = "0.2.80"
-io-uring = "0.6.0"
-socket2 = { version = "0.4.4", features = ["all"] }
-bytes = { version = "1.0", optional = true }
-futures-util = { version = "0.3.26", default-features = false, features = ["std"] }
+tokio = { version = "1.44", features = ["net", "rt", "sync"] }
+slab = "0.4.9"
+libc = "0.2.171"
+io-uring = "0.7.4"
+socket2 = { version = "0.5.9", features = ["all"] }
+bytes = { version = "1.10.1", optional = true }
+futures-util = { version = "0.3.31", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-tempfile = "3.2.0"
-tokio-test = "0.4.2"
+tempfile = "3.19.1"
+tokio-test = "0.4.4"
 iai = "0.1.1"
-criterion = "0.4.0"
+criterion = "0.5.1"
 # we use joinset in our tests
-tokio = "1.21.2"
-nix = "0.26.1"
+tokio = "1.44.2"
+nix = "0.29.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/benches/lai/no_op.rs
+++ b/benches/lai/no_op.rs
@@ -60,20 +60,26 @@ fn no_op_x1() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn no_op_x32() -> Result<(), Box<dyn std::error::Error>> {
-    let mut opts = Options::default();
-    opts.concurrency = 32;
+    let opts = Options {
+        concurrency: 32,
+        ..Options::default()
+    };
     run_no_ops(black_box(opts))
 }
 
 fn no_op_x64() -> Result<(), Box<dyn std::error::Error>> {
-    let mut opts = Options::default();
-    opts.concurrency = 64;
+    let opts = Options {
+        concurrency: 64,
+        ..Options::default()
+    };
     run_no_ops(black_box(opts))
 }
 
 fn no_op_x256() -> Result<(), Box<dyn std::error::Error>> {
-    let mut opts = Options::default();
-    opts.concurrency = 256;
+    let opts = Options {
+        concurrency: 256,
+        ..Options::default()
+    };
     run_no_ops(black_box(opts))
 }
 

--- a/benches/lai/no_op.rs
+++ b/benches/lai/no_op.rs
@@ -4,6 +4,7 @@ use tokio::task::JoinSet;
 #[derive(Clone)]
 struct Options {
     iterations: usize,
+    #[allow(dead_code)]
     concurrency: usize,
     sq_size: usize,
     cq_size: usize,

--- a/examples/tcp_listener_fixed_buffers.rs
+++ b/examples/tcp_listener_fixed_buffers.rs
@@ -34,7 +34,7 @@ async fn accept_loop(listen_addr: SocketAddr) {
     );
 
     // Other iterators may be passed to FixedBufRegistry::new also.
-    let registry = FixedBufRegistry::new(iter::repeat(vec![0; 4096]).take(POOL_SIZE));
+    let registry = FixedBufRegistry::new(iter::repeat_n(vec![0; 4096], POOL_SIZE));
 
     // Register the buffers with the kernel, asserting the syscall passed.
 

--- a/examples/test_create_dir_all.rs
+++ b/examples/test_create_dir_all.rs
@@ -163,10 +163,9 @@ async fn main1() -> io::Result<()> {
     if unexpected == 0 {
         Ok(())
     } else {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("{unexpected} unexpected result(s)"),
-        ))
+        Err(std::io::Error::other(format!(
+            "{unexpected} unexpected result(s)"
+        )))
     }
 }
 
@@ -208,10 +207,9 @@ async fn matches_mode<P: AsRef<Path>>(path: P, want_mode: u16) -> io::Result<()>
     if want_mode == got_mode {
         Ok(())
     } else {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("want mode {want_mode:#o}, got mode {got_mode:#o}"),
-        ))
+        Err(std::io::Error::other(format!(
+            "want mode {want_mode:#o}, got mode {got_mode:#o}"
+        )))
     }
 }
 
@@ -231,10 +229,7 @@ async fn is_regfile<P: AsRef<Path>>(path: P) -> io::Result<()> {
     if is_regfile {
         Ok(())
     } else {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "not regular file",
-        ))
+        Err(std::io::Error::other("not regular file"))
     }
 }
 
@@ -244,10 +239,7 @@ async fn is_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
     if is_dir {
         Ok(())
     } else {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "not directory",
-        ))
+        Err(std::io::Error::other("not directory"))
     }
 }
 

--- a/src/fs/create_dir_all.rs
+++ b/src/fs/create_dir_all.rs
@@ -124,7 +124,7 @@ impl DirBuilder {
     // recursion when only the first level of the directory needs to be built. For now, this serves
     // its purpose.
 
-    fn recurse_create_dir_all<'a>(&'a self, path: &'a Path) -> LocalBoxFuture<io::Result<()>> {
+    fn recurse_create_dir_all<'a>(&'a self, path: &'a Path) -> LocalBoxFuture<'a, io::Result<()>> {
         Box::pin(async move {
             if path == Path::new("") {
                 return Ok(());
@@ -139,10 +139,7 @@ impl DirBuilder {
             match path.parent() {
                 Some(p) => self.recurse_create_dir_all(p).await?,
                 None => {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "failed to create whole tree",
-                    ));
+                    return Err(std::io::Error::other("failed to create whole tree"));
                     /* TODO build own allocation free error some day like the std library does.
                     return Err(io::const_io_error!(
                         io::ErrorKind::Uncategorized,

--- a/src/io/accept.rs
+++ b/src/io/accept.rs
@@ -46,7 +46,7 @@ impl Completable for Accept {
         let fd = SharedFd::new(fd as i32);
         let socket = Socket { fd };
         let (_, addr) = unsafe {
-            socket2::SockAddr::init(move |addr_storage, len| {
+            socket2::SockAddr::try_init(move |addr_storage, len| {
                 self.socketaddr.0.clone_into(&mut *addr_storage);
                 *len = self.socketaddr.1;
                 Ok(())

--- a/src/io/noop.rs
+++ b/src/io/noop.rs
@@ -32,7 +32,7 @@ mod test {
     use crate as tokio_uring;
 
     #[test]
-    fn perform_no_op() -> () {
+    fn perform_no_op() {
         tokio_uring::start(async {
             tokio_uring::no_op().await.unwrap();
         })

--- a/src/io/recv_from.rs
+++ b/src/io/recv_from.rs
@@ -24,7 +24,7 @@ impl<T: BoundedBufMut> Op<RecvFrom<T>> {
             std::slice::from_raw_parts_mut(buf.stable_mut_ptr(), buf.bytes_total())
         })];
 
-        let socket_addr = Box::new(unsafe { SockAddr::init(|_, _| Ok(()))?.1 });
+        let socket_addr = Box::new(unsafe { SockAddr::try_init(|_, _| Ok(()))?.1 });
 
         let mut msghdr: Box<libc::msghdr> = Box::new(unsafe { std::mem::zeroed() });
         msghdr.msg_iov = io_slices.as_mut_ptr().cast();

--- a/src/io/recvmsg.rs
+++ b/src/io/recvmsg.rs
@@ -28,7 +28,7 @@ impl<T: BoundedBufMut> Op<RecvMsg<T>> {
             }));
         }
 
-        let socket_addr = Box::new(unsafe { SockAddr::init(|_, _| Ok(()))?.1 });
+        let socket_addr = Box::new(unsafe { SockAddr::try_init(|_, _| Ok(()))?.1 });
 
         let mut msghdr: Box<libc::msghdr> = Box::new(unsafe { std::mem::zeroed() });
         msghdr.msg_iov = io_slices.as_mut_ptr().cast();

--- a/src/io/socket.rs
+++ b/src/io/socket.rs
@@ -9,7 +9,7 @@ use crate::{
 use std::{
     io,
     net::SocketAddr,
-    os::unix::io::{AsRawFd, IntoRawFd, RawFd},
+    os::unix::io::{AsFd, AsRawFd, BorrowedFd, IntoRawFd, RawFd},
     path::Path,
 };
 
@@ -283,5 +283,13 @@ impl Socket {
 impl AsRawFd for Socket {
     fn as_raw_fd(&self) -> RawFd {
         self.fd.raw_fd()
+    }
+}
+
+impl AsFd for Socket {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe {
+            BorrowedFd::borrow_raw(self.fd.raw_fd())
+        }
     }
 }

--- a/src/io/socket.rs
+++ b/src/io/socket.rs
@@ -288,8 +288,6 @@ impl AsRawFd for Socket {
 
 impl AsFd for Socket {
     fn as_fd(&self) -> BorrowedFd<'_> {
-        unsafe {
-            BorrowedFd::borrow_raw(self.fd.raw_fd())
-        }
+        unsafe { BorrowedFd::borrow_raw(self.fd.raw_fd()) }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //! call `close()`.
 
 #![warn(missing_docs)]
-#![allow(clippy::thread_local_initializer_can_be_made_const)]
+#![allow(clippy::missing_const_for_thread_local)]
 
 macro_rules! syscall {
     ($fn: ident ( $($arg: expr),* $(,)* ) ) => {{

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -129,9 +129,8 @@ impl TcpListener {
     pub async fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
         let (socket, socket_addr) = self.inner.accept().await?;
         let stream = TcpStream { inner: socket };
-        let socket_addr = socket_addr.ok_or_else(|| {
-            io::Error::new(io::ErrorKind::Other, "Could not get socket IP address")
-        })?;
+        let socket_addr =
+            socket_addr.ok_or_else(|| io::Error::other("Could not get socket IP address"))?;
         Ok((stream, socket_addr))
     }
 }

--- a/src/runtime/driver/mod.rs
+++ b/src/runtime/driver/mod.rs
@@ -118,8 +118,7 @@ impl Driver {
                 return Ok(());
             }
         }
-        Err(io::Error::new(
-            io::ErrorKind::Other,
+        Err(io::Error::other(
             "fixed buffers are not currently registered",
         ))
     }

--- a/src/runtime/driver/op/slab_list.rs
+++ b/src/runtime/driver/op/slab_list.rs
@@ -111,7 +111,7 @@ impl<'a, T> SlabList<'a, T> {
     }
 }
 
-impl<'a, T> Drop for SlabList<'a, T> {
+impl<T> Drop for SlabList<'_, T> {
     fn drop(&mut self) {
         while !self.is_empty() {
             let removed = self.slab.remove(self.index.start);
@@ -120,7 +120,7 @@ impl<'a, T> Drop for SlabList<'a, T> {
     }
 }
 
-impl<'a, T> Iterator for SlabList<'a, T> {
+impl<T> Iterator for SlabList<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -177,13 +177,13 @@ mod test {
     #[test]
     fn block_on() {
         let rt = Runtime::new(&builder()).unwrap();
-        rt.block_on(async move { () });
+        rt.block_on(async move {});
     }
 
     #[test]
     fn block_on_twice() {
         let rt = Runtime::new(&builder()).unwrap();
-        rt.block_on(async move { () });
-        rt.block_on(async move { () });
+        rt.block_on(async move {});
+        rt.block_on(async move {});
     }
 }

--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -148,7 +148,7 @@ fn explicit_close() {
 fn drop_open() {
     tokio_uring::start(async {
         let tempfile = tempfile();
-        let _ = File::create(tempfile.path());
+        _ = File::create(tempfile.path());
 
         // Do something else
         let file = File::create(tempfile.path()).await.unwrap();


### PR DESCRIPTION
- Update dependencies
- Correct clippy lint warnings
- Remove invalid tests cases due to https://github.com/rust-lang/rust/pull/124210 - when an owned fd has already been closed before it's dropped means that something else touched the fd in ways its not allowed to. Therefore, these tests fail
due to this new behavior enforcement

CI tests were executed on fork first to ensure tests pass https://github.com/bryantbiggs/tokio-uring/actions/runs/14344438841?pr=1

Closes #324
Closes #313
Closes #272

Resolves #316